### PR TITLE
Jon/cf deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python3 -m swagger_server
+web: ONS_ENV=production python3 -m swagger_server

--- a/config.ini
+++ b/config.ini
@@ -31,3 +31,6 @@ log_level = DEBUG
 [production]
 log_level = INFO
 create_database = false
+; TODO: this is misleading, as this is the name of the service which we're binding to
+; but for now, configuration.py uses the db_name key to lookup the service
+db_name = ras-party-db

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,0 +1,12 @@
+---
+services:
+  - name: ras-party-db
+    service: rds
+    plan: shared-psql
+
+applications:
+- name: ras-party-v2
+  memory: 128M
+  host: ras-party-v2
+  services:
+  - ras-party-db

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,5 @@
+applications:
+- memory: 128M
+  name: ras-party-v2
+  services:
+  - ras-party-db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-setuptools==35.0.2
 connexion==1.0.129
 Flask==0.12.1
 Flask_Cors==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask_Cors==3.0.2
 SQLAlchemy_Utils==0.32.14
 SQLAlchemy==1.1.10
 six==1.10.0
+psycopg2==2.7.1
 pycrypto==2.6.1
 python_dateutil==2.6.0
 PyYAML==3.12


### PR DESCRIPTION
Changes to enable deployment to current AWS/CloudFoundry. Currently accessible at http://ras-party-v2.apps.mvp.onsclofo.uk/party-api/1.0.0/ui (Swagger UI).