### PR TITLE
Updates for running with 0.3 API GW

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python3 -m swagger_server
+web: ONS_ENV=demo python3 -m swagger_server

--- a/config.ini
+++ b/config.ini
@@ -46,9 +46,13 @@ db_host = localhost
 ;
 ;   db_service needs to point at the name of the cloud foundry database service
 ;
-api_gateway = localhost
+api_protocol = http
+api_host = localhost
 api_port = 8080
-protocol = http
+;
+flask_protocol = http
+flask_host = localhost
+;
 db_service = ras-party-db
 ;
 ;   these settings are for development only. debug will enable the debug flag
@@ -92,6 +96,10 @@ db_connection = ${db_driver}://${db_user}:${db_pass}@${db_host}:${db_port}/${db_
 db_schema = ras
 
 [demo]
+pi_protocol = https
+api_host = api-demo.apps.mvp.onsclofo.uk
+api_port = 443
+authentication = false
 api_gateway = api-demo.apps.mvp.onsclofo.uk
 protocol = https
 db_service = ras-party-db-demo

--- a/config.ini
+++ b/config.ini
@@ -96,7 +96,7 @@ db_connection = ${db_driver}://${db_user}:${db_pass}@${db_host}:${db_port}/${db_
 db_schema = ras
 
 [demo]
-pi_protocol = https
+api_protocol = https
 api_host = api-demo.apps.mvp.onsclofo.uk
 api_port = 443
 authentication = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ONSdigital/ras-common.git@master/0.3#ons_ras_common==0.1.82
+git+https://github.com/ONSdigital/ras-common.git@release/0.3#ons_ras_common==0.1.82
 connexion==1.0.129
 Flask==0.12.1
 Flask_Cors==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ONSdigital/ras-common.git@shim#ons_ras_common==0.1.82
+git+https://github.com/ONSdigital/ras-common.git@master/0.3#ons_ras_common==0.1.82
 connexion==1.0.129
 Flask==0.12.1
 Flask_Cors==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/ONSdigital/ras-common.git@shim#ons_ras_common==0.1.82
 connexion==1.0.129
 Flask==0.12.1
 Flask_Cors==3.0.2
@@ -8,4 +9,3 @@ psycopg2==2.7.1
 pycrypto==2.6.1
 python_dateutil==2.6.0
 PyYAML==3.12
-ons-ras-common==0.1.21

--- a/swagger_server/swagger/swagger.yaml
+++ b/swagger_server/swagger/swagger.yaml
@@ -76,6 +76,7 @@ definitions:
       href: {example: /party/id/12345678, type: string}
       rel: {example: self, type: string}
       type: {example: application/vnd.ons.party+json, type: string}
+host: localhost:8080
 info:
   contact: {email: ras@ons.gov.uk}
   description: Initial API for the Party microservice.
@@ -108,8 +109,6 @@ paths:
         422:
           description: an existing item already exists
           schema: {$ref: '#/definitions/error'}
-      security:
-      - accessCode: [write]
       summary: adds a reporting unit of type Business
       x-swagger-router-controller: swagger_server.controllers_local.controller
   /businesses/id/{id}:
@@ -186,8 +185,6 @@ paths:
         422:
           description: an existing item already exists
           schema: {$ref: '#/definitions/error'}
-      security:
-      - accessCode: [write]
       summary: given a sampleUnitType B | H this adds a reporting unit of type Business
         or Household
       x-swagger-router-controller: swagger_server.controllers_local.controller
@@ -271,8 +268,6 @@ paths:
         400:
           description: invalid input, object invalid
           schema: {$ref: '#/definitions/error'}
-      security:
-      - accessCode: [write]
       summary: adds a Respondent
       x-swagger-router-controller: swagger_server.controllers_local.controller
   /respondents/id/{id}:
@@ -296,15 +291,6 @@ paths:
       summary: Get a Respondent by its Party ID
       x-swagger-router-controller: swagger_server.controllers_local.controller
 schemes: [https]
-security:
-- accessCode: [read]
-securityDefinitions:
-  accessCode:
-    authorizationUrl: http://uaa.ons.gov.uk/oauth/auth
-    flow: accessCode
-    scopes: {read: allows reading resources, write: allows modifying resources}
-    tokenUrl: http://uaa.ons.gov.uk/oauth/token
-    type: oauth2
 swagger: '2.0'
 tags:
 - {description: 'Operations available to internal business roles (i.e. Respondent


### PR DESCRIPTION
This introduced dependencies based on the new common code but in particular on the API GW. This version needs to run against an 0.3+ version of the GW. I've also removed the old security code that we're no longer using (from the swagger file) which makes the startup far less noisy ..)