### PR TITLE
Feature/use uppercase vars

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,13 +20,13 @@
 # db_uri = current_app.config.dependency['ras-party-db'].uri
 
 service:
-    name: ras-party
-    version: 0.0.1
-    scheme: httpx
-    host: 0.0.0.0
-    port: 5201
-    debug: True
-    log_level: debug
+    NAME: ras-party
+    VERSION: 0.0.1
+    SCHEME: http
+    HOST: 0.0.0.0
+    PORT: 8080
+    DEBUG: False
+    LOG_LEVEL: debug
 
 dependencies:
     ras-party-db:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ONSdigital/ras-common-utils.git@0.0.1
+git+https://github.com/ONSdigital/ras-common-utils.git@0.0.2
 Flask==0.12.2
 Flask_Cors==3.0.3
 SQLAlchemy_Utils==0.32.14

--- a/run.py
+++ b/run.py
@@ -50,9 +50,9 @@ if __name__ == '__main__':
 
     initialise_db(app)
 
-    scheme, host, port = app.config['scheme'], app.config['host'], app.config['port']
+    scheme, host, port = app.config['SCHEME'], app.config['HOST'], int(app.config['PORT'])
 
     if app.config.feature.gateway_registration:
         call_in_background(make_registration_func(app))
 
-    app.run(debug=app.config['debug'], port=int(port))
+    app.run(debug=app.config['DEBUG'], host=host, port=port)

--- a/swagger_server/test/fixtures/config.py
+++ b/swagger_server/test/fixtures/config.py
@@ -1,11 +1,11 @@
 test_config = """
 service:
-    name: ras-party
-    version: 0.0.1
-    scheme: http
-    host: 0.0.0.0
-    port: 8000
-    log_level: error
+    NAME: ras-party
+    VERSION: 0.0.1
+    SCHEME: http
+    HOST: 0.0.0.0
+    PORT: 8000
+    LOG_LEVEL: error
 
 dependencies:
     ras-party-db:


### PR DESCRIPTION
Uses upper-case names for environment variables, in order to ensure that PORT and other settings are correctly overridden in CloudFoundry.