### PR TITLE
Add uk gov notify and tests

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -46,11 +46,10 @@ dependencies:
         scheme: http
         host: localhost
         port: 8080
-    govuk-notify-service:
-        # TODO: find out the correct values
-        scheme: http
-        host: unknown
-        port: unknown
+    gov-uk-notify-service:
+        gov_notify_api_key: notify_key_placeholder
+        gov_notify_template_id: notify_template_id_placeholder
+        gov_notify_service_id: notify_service_id_placeholder
     frontstage-service:
         # TODO: find out the correct values
         scheme: http

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/ONSdigital/ras-common-utils.git@0.0.2
 Flask==0.12.2
 Flask_Cors==3.0.3
 gunicorn==19.7.1
+notifications-python-client==4.3.1
 SQLAlchemy_Utils==0.32.14
 SQLAlchemy==1.1.10
 six==1.10.0

--- a/swagger_server/controllers/gov_uk_notify.py
+++ b/swagger_server/controllers/gov_uk_notify.py
@@ -1,0 +1,37 @@
+from flask import current_app
+from notifications_python_client.notifications import NotificationsAPIClient
+from structlog import get_logger
+from swagger_server.controllers.ras_error import RasNotifyError
+
+log = get_logger()
+
+
+class GovUKNotify:
+    """ Gov uk notify class"""
+
+    def __init__(self):
+        notify_service = current_app.config.dependency['gov-uk-notify-service']
+        notify_keys = 'key-name-{}-{}'.format(notify_service['gov_notify_service_id'],
+                                              notify_service['gov_notify_api_key'])
+        self.notifications_client = NotificationsAPIClient(notify_keys)
+
+    def send_message(self, email, template_id, personalisation=None, reference=None):
+        """
+         Send message to gov.uk notify
+         :param email: email address of recipient
+         :param template_id: the template id on gov.uk notify to use
+         :param personalisation: placeholder values in the template
+         :param reference: reference to generated if not using Notify's id
+         :rtype: 201 if success
+         """
+        try:
+            response = self.notifications_client.send_email_notification(
+                email_address=email,
+                template_id=template_id,
+                personalisation=personalisation,
+                reference=reference)
+            log.info('Message sent to gov.uk notify with notification id {}'.format(response.id))
+        except Exception as e:
+            log.error('Gov uk notify can not send the message' + str(e))
+            raise RasNotifyError(status_code=400)
+        return 201

--- a/swagger_server/controllers/ras_error.py
+++ b/swagger_server/controllers/ras_error.py
@@ -11,3 +11,7 @@ class RasError(Exception):
 
 class RasDatabaseError(RasError):
     pass
+
+
+class RasNotifyError(RasError):
+    pass

--- a/swagger_server/test/fixtures/config.py
+++ b/swagger_server/test/fixtures/config.py
@@ -25,6 +25,10 @@ dependencies:
         scheme: http
         host: mockhost
         port: 3333
+    gov-uk-notify-service:
+        gov_notify_api_key: notify_api_key_placeholder
+        gov_notify_template_id: notify_template_id_placeholder
+        gov_notify_service_id: notify_service_id__placeholder
 
 features:
     skip_oauth_registration: true

--- a/swagger_server/test/test_gov_uk_notify.py
+++ b/swagger_server/test/test_gov_uk_notify.py
@@ -1,0 +1,38 @@
+from requests.models import Response
+from swagger_server.controllers.gov_uk_notify import GovUKNotify
+from swagger_server.test.party_client import PartyTestClient
+from swagger_server.controllers.ras_error import RasNotifyError
+from unittest.mock import patch, Mock
+
+
+class TestParties(PartyTestClient):
+    """ Gov uk notify test class"""
+
+    def test_notify(self):
+
+        # Given a mocked gov.uk notify and response
+        mock_response = Response()
+        mock_response.status_code = 201
+        mock_response.id = 'notification id'
+        notify_patch = Mock()
+        notify_patch.send_email_notification = Mock(return_value=mock_response)
+
+        with patch('swagger_server.controllers.gov_uk_notify.NotificationsAPIClient', return_value=notify_patch):
+            notify = GovUKNotify()
+            # When a email is sent
+            response = notify.send_message('email', 'template_id')
+            # Then a message is created
+            self.assertEquals(response, 201)
+
+    def test_notify_exception(self):
+
+        # Given a mocked gov.uk notify and exception
+        notify_patch = Mock()
+        notify_patch.send_email_notification = Mock(side_effect=Exception)
+
+        with patch('swagger_server.controllers.gov_uk_notify.NotificationsAPIClient', return_value=notify_patch):
+            # When an email is sent
+            notify = GovUKNotify()
+            # Then a RasNotifyError is raised
+            with self.assertRaises(RasNotifyError):
+                notify.send_message('email', 'template_id')


### PR DESCRIPTION
### What is the context of this PR?
To add in the functionality to use gov.uk notify. This has been isolated away from the code and will be plugged in later. 

### How to review 
At present a live test is not possible as there is no key management process, meaning the real keys aren't represent on the repo. So this review is code structure more then anything else