### PR TITLE
Feature/tbl050 set oauth2 user active

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -68,6 +68,7 @@ dependencies:
         authorization_endpoint: "/web/authorize/"
         token_endpoint: "/api/v1/tokens/"
         admin_endpoint: "/api/account/create"
+        activae_endpoint: "/api/account/activate"
         client_id: "ons@ons.gov"
         client_secret: "password"
 

--- a/ras_party/controllers/controller.py
+++ b/ras_party/controllers/controller.py
@@ -285,6 +285,7 @@ def put_email_verification(token):
         return make_response(jsonify(r.to_respondent_dict()), 200)
 
 
+# Helper function to set the 'active' flag on the OAuth2 server for a user. If it fails a raise_for_status is executed
 def set_user_active(respondent_email):
 
     log.info("Setting user active on OAuth2 server")

--- a/ras_party/controllers/ras_error.py
+++ b/ras_party/controllers/ras_error.py
@@ -1,6 +1,8 @@
 
 class RasError(Exception):
     status_code = 500
+    #TODO A RasError will need to deal with more than just a HTTP 500. e.g. Party Service registers a user who has a duplicate
+    # user id. It will have to convey this to the calling party (ras_frontstage) so that it can deal correclty with this issue.
 
     def __init__(self, errors, status_code=None):
         self.errors = errors if type(errors) is list else [errors]

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -70,3 +70,4 @@ def post_respondent():
 @log_route
 def put_email_verification(token):
     return controller.put_email_verification(token)
+


### PR DESCRIPTION
To add a helper function to allow the party service to set the active flag on the OAuth2 server. Test cases to come. Can't add them until I can get this merged to John.B's changes to the creation of respondent code additions.
This change has to be added to cloud foundry after the change has gone live to the OAuth2 server.