### PR TITLE
Feature/us167 internal change respondents email address

### DIFF
--- a/API.md
+++ b/API.md
@@ -180,3 +180,26 @@ This page documents the Party service API endpoints. All endpoints return an `HT
     "status": "ACTIVE"
 }
 ```
+
+* `PUT /respondents/email`
+### Example JSON DATA for the put
+```json
+{
+   "email_address": "old@email.com",
+   "new_email_address": "new@email.com"
+}
+```
+&mdash; This endpoint will update a respondent's email in the ras-party database and the oauth2 server. This email will need verified again so it will also set the user as unverified in the oauth server and will send a new verification email to the respondent.
+
+### Example JSON Response
+```json
+{
+   "emailAddress": "testtest@test.test",
+   "firstName": "Test",
+   "id": "ef7737df-2097-4a73-a530-e98dba7bfe43",
+   "lastName": "tseT",
+   "sampleUnitType": "BI",
+   "status": "ACTIVE",
+   "telephone": "07846608000"
+}
+```

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,7 +40,7 @@ service:
 dependencies:
     ras-party-db:
         schema: partysvc
-        uri: "postgres:///rasparty"
+        uri: "sqlite:///ras-party"
     case-service:
         scheme: http
         host: localhost

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,7 +40,7 @@ service:
 dependencies:
     ras-party-db:
         schema: partysvc
-        uri: "sqlite:///ras-party"
+        uri: "postgres:///rasparty"
     case-service:
         scheme: http
         host: localhost

--- a/ras_party/controllers/controller.py
+++ b/ras_party/controllers/controller.py
@@ -657,7 +657,8 @@ def _send_message_to_gov_uk_notify(email, template_id, url, party_id):
 def change_respondent_email(old_email_address, new_email_address, session):
     respondent = session.query(Respondent).filter(Respondent.email_address == old_email_address).first()
     if not respondent:
-        return make_response(jsonify({'errors': "Respondent with email '{}' does not exist.".format(old_email_address)}), 404)
+        return make_response(
+            jsonify({'errors': "Respondent with email '{}' does not exist.".format(old_email_address)}), 404)
     log.debug("Changing respondent's email", party_id=respondent.party_uuid)
 
     respondent.email_address = new_email_address

--- a/ras_party/controllers/controller.py
+++ b/ras_party/controllers/controller.py
@@ -391,23 +391,7 @@ def set_user_verified(respondent_email):
         If it fails a raise_for_status is executed
     """
     log.info("Setting user active on OAuth2 server")
-
-    client_id = current_app.config.dependency['oauth2-service']['client_id']
-    client_secret = current_app.config.dependency['oauth2-service']['client_secret']
-
-    oauth_payload = {
-        "username": respondent_email,
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "account_verified": "true"
-    }
-    oauth_svc = current_app.config.dependency['oauth2-service']
-    oauth_url = build_url('{}://{}:{}{}', oauth_svc, oauth_svc['admin_endpoint'])
-    auth = (client_id, client_secret)
-    oauth_response = Requests.put(oauth_url, auth=auth, data=oauth_payload)
-    if not oauth_response.status_code == 201:
-        log.error("Unable to set the user active on the OAuth2 server")
-        oauth_response.raise_for_status()
+    update_oauth_user(original_email=respondent_email, verified='true')
     log.info("User has been activated on the oauth2 server")
 
 

--- a/ras_party/controllers/controller.py
+++ b/ras_party/controllers/controller.py
@@ -29,7 +29,6 @@ log = get_logger()
 NO_RESPONDENT_FOR_PARTY_ID = 'There is no respondent with that party ID '
 EMAIL_ALREADY_VERIFIED = 'The Respondent for that party ID is already verified'
 EMAIL_VERIFICATION_SEND = 'A new verification email has been sent'
-EMAIL_CHANGED = 'Respondents email has been changed'
 
 #
 #   TODO: the spec seems to read as a need for /info, currently this endpoint responds on /party-api/v1/info

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -79,6 +79,19 @@ def get_respondent_by_email(email):
     return controller.get_respondent_by_email(email)
 
 
+@party_view.route('/respondents/email', methods=['PUT'])
+@auth.login_required
+@log_route
+def change_respondent_email():
+    request_data = request.json
+    email_address = request_data.get('email_address')
+    new_email_address = request_data.get('new_email_address')
+    if not email_address or not new_email_address:
+        return make_response(jsonify({'errors': 'No email provided'}), 400)
+
+    return controller.change_respondent_email(email_address, new_email_address)
+
+
 @party_view.route('/respondents', methods=['POST'])
 @auth.login_required
 @log_route
@@ -99,16 +112,3 @@ def put_email_verification(token):
 @log_route
 def resend_verification_email(party_uuid):
     return controller.resend_verification_email(party_uuid)
-
-
-@party_view.route('/change-respondent-email/<party_uuid>', methods=['POST'])
-@auth.login_required
-@log_route
-def change_respondent_email(party_uuid):
-    request_data = request.json
-    email_address = request_data.get('email')
-
-    if not email_address:
-        return make_response(jsonify({'errors': 'No email provided'}), 400)
-
-    return controller.change_respondent_email(party_uuid, email_address)

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, current_app
+from flask import Blueprint, current_app, jsonify, make_response, request
 from flask_httpauth import HTTPBasicAuth
 
 from ras_party.controllers import controller
@@ -99,3 +99,16 @@ def put_email_verification(token):
 @log_route
 def resend_verification_email(party_uuid):
     return controller.resend_verification_email(party_uuid)
+
+
+@party_view.route('/change-respondent-email/<party_uuid>', methods=['POST'])
+@auth.login_required
+@log_route
+def change_respondent_email(party_uuid):
+    request_data = request.json
+    email_address = request_data.get('email')
+
+    if not email_address:
+        return make_response(jsonify({'errors': 'No email provided'}), 400)
+
+    return controller.change_respondent_email(party_uuid, email_address)

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -76,6 +76,14 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
+    def put_email_to_respondents(self, payload, expected_status):
+        response = self.client.put('/party-api/v1/respondents/email',
+                                   headers=self.auth_headers,
+                                   data=json.dumps(payload),
+                                   content_type='application/vnd.ons.business+json')
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))
+
     def get_party_by_ref(self, party_type, ref, expected_status=200):
         response = self.client.get('/party-api/v1/parties/type/{}/ref/{}'.format(party_type, ref),
                                    headers=self.auth_headers)


### PR DESCRIPTION
- Added endpoint  `PUT /respondents/email` which can be used to change user's email address(username)
- added function `update_oauth_user` which can update any oauth value for users.
- Added a couple of tests around this functionality