### PR TITLE
removing active respondent check for resend email

### DIFF
--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -22,7 +22,6 @@ from ras_party.support.verification import decode_email_token
 log = get_logger()
 
 NO_RESPONDENT_FOR_PARTY_ID = 'There is no respondent with that party ID '
-EMAIL_ALREADY_VERIFIED = 'The Respondent for that party ID is already verified'
 EMAIL_VERIFICATION_SENT = 'A new verification email has been sent'
 
 

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -623,16 +623,11 @@ def resend_verification_email(party_uuid):
     :param party_uuid: the party uuid
     :return: make_response
     """
-    log.debug('attempting to resend verification_email with party_uuid {}'.format(party_uuid))
+    log.debug('Attempting to resend verification_email with party_uuid {}'.format(party_uuid))
 
     respondent = _query_respondent_by_party_uuid(party_uuid)
-
     if not respondent:
         raise RasError(NO_RESPONDENT_FOR_PARTY_ID, status_code=404)
-
-    if respondent.status == RespondentStatus.ACTIVE:
-        log.debug(EMAIL_ALREADY_VERIFIED)
-        return EMAIL_ALREADY_VERIFIED
 
     _send_email_verification(party_uuid, respondent.email_address)
 
@@ -652,6 +647,7 @@ def _send_email_verification(party_id, email):
 
     try:
         GovUkNotify(current_app.config).verify_email(email, personalisation, str(party_id))
+        log.info("Verification email sent", party_id=party_id)
     except RasNotifyError:
         # Note: intentionally suppresses exception
         log.error("Error sending verification email for party_id {}".format(party_id))

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -368,25 +368,6 @@ class TestParties(PartyTestClient):
         # When the resend verification end point is hit
         self.resend_verification_email(resp['id'], 200)
 
-    def test_resend_verification_email_status_active(self):
-        mock_notify = MagicMock()
-        ras_party.controllers.party_controller.GovUkNotify.CLIENT_CLASS = MagicMock(return_value=mock_notify)
-        # Given there is a business and respondent and the account is already active
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        resp = self.post_to_respondents(mock_respondent, 200)
-        frontstage_url = mock_notify.send_email_notification.call_args[1]['personalisation']['ACCOUNT_VERIFICATION_URL']
-        token = frontstage_url.split('/')[-1]
-        self.put_email_verification(token, 200)
-
-        # When the resend verification end point is hit
-        response = self.resend_verification_email(resp['id'], 200)
-
-        # Then an email is not sent and a message saying the account is already active is returned
-        self.assertEqual(response, EMAIL_ALREADY_VERIFIED)
-
     def test_resend_verification_email_party_id_not_found(self):
 
         # Given the party_id sent doesn't exist

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from itsdangerous import URLSafeTimedSerializer
 
 import ras_party
-from ras_party.controllers.party_controller import EMAIL_ALREADY_VERIFIED, NO_RESPONDENT_FOR_PARTY_ID
+from ras_party.controllers.party_controller import NO_RESPONDENT_FOR_PARTY_ID
 from ras_party.models.models import RespondentStatus
 from ras_party.support.requests_wrapper import Requests
 from test.mocks import MockBusiness, MockRespondent, MockRequests, MockResponse


### PR DESCRIPTION
Removing a restriction to allow users to have their verification email sent if their status is set to `ACTIVE`

Removed a test related to this