### PR TITLE
Email address exposed in some urls and logs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,7 +39,7 @@ service:
 dependencies:
     ras-party-db:
         schema: partysvc
-        uri: "sqlite:///ras-party"
+        uri: "postgres://postgres:postgres@db:5432/postgres"
     public-website:
         scheme: http
         host: dummy.ons.gov.uk

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,7 +39,7 @@ service:
 dependencies:
     ras-party-db:
         schema: partysvc
-        uri: "postgres://postgres:postgres@db:5432/postgres"
+        uri: "sqlite:///ras-party"
     public-website:
         scheme: http
         host: dummy.ons.gov.uk

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -76,11 +76,11 @@ def get_respondent_by_id(id):
     return make_response(jsonify(response), 200)
 
 
-@party_view.route('/respondents/email/<string:email>', methods=['GET'])
+@party_view.route('/respondents/email/<string:token>', methods=['GET'])
 @auth.login_required
 @log_route
-def get_respondent_by_email(email):
-    response = ras_party.controllers.party_controller.get_respondent_by_email(email)
+def get_respondent_by_email(token):
+    response = ras_party.controllers.party_controller.get_respondent_by_email(token)
     return make_response(jsonify(response), 200)
 
 

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -8,6 +8,7 @@ from ras_common_utils.ras_config import ras_config
 from ras_common_utils.ras_logger.ras_logger import configure_logger
 
 from ras_party.models.models import Business, Respondent, BusinessRespondent, Enrolment
+from ras_party.support.verification import generate_email_token
 from run import create_app, initialise_db
 from test.fixtures import party_schema
 from test.fixtures.config import test_config
@@ -46,6 +47,11 @@ class PartyTestClient(TestCase):
         return {
             'Authorization': 'Basic %s' % base64.b64encode(b"username:password").decode("ascii")
         }
+
+    @staticmethod
+    def generate_token(email):
+        token = generate_email_token(email, current_app.config)
+        return token
 
     def get_info(self, expected_status=200):
         response = self.client.open('/info', method='GET')
@@ -108,6 +114,11 @@ class PartyTestClient(TestCase):
 
     def get_respondent_by_id(self, id, expected_status=200):
         response = self.client.get('/party-api/v1/respondents/id/{}'.format(id), headers=self.auth_headers)
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))
+
+    def get_respondent_by_email(self, token, expected_status=200):
+        response = self.client.get('/party-api/v1/respondents/email/{}'.format(token), headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -355,6 +355,22 @@ class TestParties(PartyTestClient):
     def test_get_respondent_with_invalid_id(self):
         self.get_respondent_by_id('123', 400)
 
+    def test_get_respondent_by_email_success(self):
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        self.post_to_respondents(mock_respondent, 200)
+        email = mock_respondent['emailAddress']
+        token = self.generate_token(email)
+        self.get_respondent_by_email(token, 200)
+
+    def test_get_respondent_by_email_no_respondent(self):
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        email = mock_respondent['emailAddress']
+        token = self.generate_token(email)
+        self.get_respondent_by_email(token, 404)
+
     def test_resend_verification_email(self):
         mock_notify = MagicMock()
         ras_party.controllers.party_controller.GovUkNotify.CLIENT_CLASS = MagicMock(return_value=mock_notify)


### PR DESCRIPTION
`get_respondent_by_email` endpoint now receives an encrypted email token rather than a standard email string.

This is then decoded in the same way as the other `token` endpoints in party services.

Factored out a `get_email_from_token` function which was used in several places

This change works in conjunction with https://github.com/ONSdigital/ras-frontstage/pull/211

https://trello.com/c/dUefc87O/667-email-address-exposed-in-some-urls-and-logs