### PR TITLE
[71] Search email case insensitive for password reset

### DIFF
--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -3,7 +3,7 @@ import uuid
 from flask import current_app
 from itsdangerous import SignatureExpired, BadSignature, BadData
 from ras_common_utils.ras_error.ras_error import RasError, RasNotifyError
-from sqlalchemy import orm
+from sqlalchemy import orm, func
 from structlog import get_logger
 
 from ras_party.clients.oauth_client import OauthClient
@@ -331,10 +331,11 @@ def request_password_change(payload, session):
 
     email_address = payload['email_address']
 
-    respondent = session.query(Respondent).filter(Respondent.email_address == email_address).first()
+    respondent = session.query(Respondent).filter(func.lower(Respondent.email_address) == email_address.lower()).first()
     if not respondent:
         raise RasError("Respondent does not exist.", status_code=404)
 
+    email_address = respondent.email_address
     verification_url = PublicWebsite(current_app.config).reset_password_url(email_address)
 
     personalisation = {

--- a/test/fixtures/config.py
+++ b/test/fixtures/config.py
@@ -40,7 +40,8 @@ dependencies:
         api_key: notify_api_key
         service_id: sdc_service_id
         email_verification_template: email_verification_id
-        reset_password_template: reset_password_id
+        request_password_change_template: request_password_change_id
+        confirm_password_change_template: confirm_password_change_id
     oauth2-service:
         scheme: http
         host: mockhost

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -121,3 +121,11 @@ class PartyTestClient(TestCase):
                                    headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
+
+    def request_password_change(self, email, expected_status=200):
+        response = self.client.post('/party-api/v1/respondents/request_password_change',
+                                    data=json.dumps({'email_address': email}),
+                                    headers=self.auth_headers,
+                                    content_type='application/vnd.ons.business+json')
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))


### PR DESCRIPTION
Case insensitive search when looking for email to reset password. This
will allow users to put their email in any case and still reset their
password.

test.test_party_controller.TestParties#test_should_reset_password_when_email_wrong_case
demonstrates a call to the reset password api with an email address with
a different case to the email address stored.