### PR TITLE
TBL098 (P3) Verbose Business Party

### DIFF
--- a/API.md
+++ b/API.md
@@ -56,11 +56,11 @@ This page documents the Party service API endpoints. All endpoints return an `HT
         "cell_no": 1,     
         "formtype": "0001",
         "currency": "H",
-        "name": "Bolts and Ratchets Ltd"
     },
     "id": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
     "sampleUnitRef": "50012345678",
-    "sampleUnitType": "B"
+    "sampleUnitType": "B",
+    "name": "Bolts and Ratchets Ltd"
 }
 ```
 
@@ -84,13 +84,40 @@ This page documents the Party service API endpoints. All endpoints return an `HT
         "partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"
         }
     ],
+    "name": "Bolts and Ratchets Ltd",
+    "id": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+    "sampleUnitRef": "50012345678",
+    "sampleUnitType": "B"
+}
+```
+
+*  Using verbose parameter: `GET /businesses/id/d826818e-179e-467b-9936-6a8603dc8b46?verbose=true`
+
+&mdash; Verbose concrete representation of the business party.
+
+### Example JSON Response
+
+```json
+{
+    "associations": [
+        {
+        "enrolments": [
+            {
+                "enrolmentStatus": "ENABLED",
+                "name": "Business Register and Employment Survey",
+                "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            }
+        ],
+        "partyId": "cd592e0f-8d07-407b-b75d-e01fbdae8233"
+        }
+    ],
     "ruref": "50012345678",
     "checkletter": "A",
     "frosic92": "11111",
     "rusic92": "11111",
     "frosic2007": "11111",
     "rusic2007": "11111",
-    "froempment": 50,    
+    "froempment": 50,
     "frotover": 50,
     "entref": "1234567890",
     "legalstatus": "B",
@@ -108,7 +135,7 @@ This page documents the Party service API endpoints. All endpoints return an `HT
     "tradstyle3": "TRADSTYLE3",
     "seltype": "F",
     "inclexcl": "G",
-    "cell_no": 1,     
+    "cell_no": 1,
     "formtype": "0001",
     "currency": "H",
     "name": "Bolts and Ratchets Ltd",

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -47,24 +47,24 @@ def get_business_by_ref(ref, session, verbose=False):
 
 @translate_exceptions
 @with_db_session
-def get_business_by_id(id, session, verbose=False):
+def get_business_by_id(party_uuid, session, verbose=False):
     """
     Get a Business by its Party ID
     Returns a single Party
-    :param id: ID of Party to return
-    :type id: str
+    :param party_uuid: ID of Party to return
+    :type party_uuid: str
 
     :param verbose: Verbosity of business details
 
     :rtype: Business
     """
     v = Validator(IsUuid('id'))
-    if not v.validate({'id': id}):
+    if not v.validate({'id': party_uuid}):
         raise RasError(v.errors, status_code=400)
 
-    business = session.query(Business).filter(Business.party_uuid == id).first()
+    business = session.query(Business).filter(Business.party_uuid == party_uuid).first()
     if not business:
-        raise RasError("Business with party id '{}' does not exist.".format(id), status_code=404)
+        raise RasError("Business with party id '{}' does not exist.".format(party_uuid), status_code=404)
 
     return business.to_business_dict(summary=not verbose)
 

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -42,7 +42,10 @@ def get_business_by_ref(ref, session, verbose=False):
     if not business:
         raise RasError("Business with reference '{}' does not exist.".format(ref), status_code=404)
 
-    return business.to_business_dict(summary=not verbose)
+    if verbose:
+        return business.to_business_dict()
+    else:
+        return business.to_business_summary_dict()
 
 
 @translate_exceptions
@@ -66,7 +69,10 @@ def get_business_by_id(party_uuid, session, verbose=False):
     if not business:
         raise RasError("Business with party id '{}' does not exist.".format(party_uuid), status_code=404)
 
-    return business.to_business_dict(summary=not verbose)
+    if verbose:
+        return business.to_business_dict()
+    else:
+        return business.to_business_summary_dict()
 
 
 @translate_exceptions

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -27,12 +27,14 @@ EMAIL_VERIFICATION_SENT = 'A new verification email has been sent'
 
 @translate_exceptions
 @with_db_session
-def get_business_by_ref(ref, session):
+def get_business_by_ref(ref, session, verbose=False):
     """
     Get a Business by its unique business reference
     Returns a single Business
     :param ref: Reference of the Business to return
     :type ref: str
+
+    :param verbose: Verbosity of business details
 
     :rtype: Business
     """
@@ -40,17 +42,19 @@ def get_business_by_ref(ref, session):
     if not business:
         raise RasError("Business with reference '{}' does not exist.".format(ref), status_code=404)
 
-    return business.to_business_dict()
+    return business.to_business_dict(summary=not verbose)
 
 
 @translate_exceptions
 @with_db_session
-def get_business_by_id(id, session):
+def get_business_by_id(id, session, verbose=False):
     """
     Get a Business by its Party ID
     Returns a single Party
     :param id: ID of Party to return
     :type id: str
+
+    :param verbose: Verbosity of business details
 
     :rtype: Business
     """
@@ -62,7 +66,7 @@ def get_business_by_id(id, session):
     if not business:
         raise RasError("Business with party id '{}' does not exist.".format(id), status_code=404)
 
-    return business.to_business_dict()
+    return business.to_business_dict(summary=not verbose)
 
 
 @translate_exceptions

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -83,14 +83,27 @@ class Business(Base):
             associations.append(respondent_dict)
         return associations
 
-    def to_business_dict(self):
-        d = {
-            'id': self.party_uuid,
-            'sampleUnitRef': self.business_ref,
-            'sampleUnitType': self.UNIT_TYPE,
-            'associations': self._get_respondents_associations(self.respondents),
-        }
-        return dict(d, **self.attributes)
+    def to_business_dict(self, summary=False):
+
+        if summary:
+            d = {
+                'id': self.party_uuid,
+                'sampleUnitRef': self.business_ref,
+                'sampleUnitType': self.UNIT_TYPE,
+                'name': self.attributes.get('name'),
+                'associations': self._get_respondents_associations(self.respondents)
+            }
+
+            return d
+        else:
+            d = {
+                'id': self.party_uuid,
+                'sampleUnitRef': self.business_ref,
+                'sampleUnitType': self.UNIT_TYPE,
+                'associations': self._get_respondents_associations(self.respondents),
+            }
+
+            return dict(d, **self.attributes)
 
     def to_party_dict(self):
         return {
@@ -98,6 +111,7 @@ class Business(Base):
             'sampleUnitRef': self.business_ref,
             'sampleUnitType': self.UNIT_TYPE,
             'attributes': self.attributes,
+            'name': self.attributes.get('name'),
             'associations': self._get_respondents_associations(self.respondents)
         }
 

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -83,27 +83,21 @@ class Business(Base):
             associations.append(respondent_dict)
         return associations
 
-    def to_business_dict(self, summary=False):
+    def to_business_dict(self):
+        d = self.to_business_summary_dict()
 
-        if summary:
-            d = {
-                'id': self.party_uuid,
-                'sampleUnitRef': self.business_ref,
-                'sampleUnitType': self.UNIT_TYPE,
-                'name': self.attributes.get('name'),
-                'associations': self._get_respondents_associations(self.respondents)
-            }
+        return dict(d, **self.attributes)
 
-            return d
-        else:
-            d = {
-                'id': self.party_uuid,
-                'sampleUnitRef': self.business_ref,
-                'sampleUnitType': self.UNIT_TYPE,
-                'associations': self._get_respondents_associations(self.respondents),
-            }
+    def to_business_summary_dict(self):
+        d = {
+            'id': self.party_uuid,
+            'sampleUnitRef': self.business_ref,
+            'sampleUnitType': self.UNIT_TYPE,
+            'name': self.attributes.get('name'),
+            'associations': self._get_respondents_associations(self.respondents)
+        }
 
-            return dict(d, **self.attributes)
+        return d
 
     def to_party_dict(self):
         return {

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -31,7 +31,10 @@ def post_business():
 @auth.login_required
 @log_route
 def get_business_by_id(id):
-    response = ras_party.controllers.party_controller.get_business_by_id(id)
+    verbose = request.args.get('verbose', '')
+    verbose = True if verbose and verbose.lower() == 'true' else False
+
+    response = ras_party.controllers.party_controller.get_business_by_id(id, verbose=verbose)
     return make_response(jsonify(response), 200)
 
 
@@ -39,7 +42,10 @@ def get_business_by_id(id):
 @auth.login_required
 @log_route
 def get_business_by_ref(ref):
-    response = ras_party.controllers.party_controller.get_business_by_ref(ref)
+    verbose = request.args.get('verbose', '')
+    verbose = True if verbose and verbose.lower() == 'true' else False
+
+    response = ras_party.controllers.party_controller.get_business_by_ref(ref, verbose=verbose)
     return make_response(jsonify(response), 200)
 
 

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -42,7 +42,8 @@ class MockBusiness:
             "rusic92": "rusic92",
             "seltype": "seltype",
             "tradstyle1": "tradstyle1",
-            "cell_no": 1
+            "cell_no": 1,
+            "name": 'Runame-1 Runame-2 Runame-3'
         }
 
     def attributes(self, **kwargs):

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -96,14 +96,14 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def get_business_by_id(self, id, expected_status=200, query_string={}):
+    def get_business_by_id(self, id, expected_status=200, query_string=None):
         response = self.client.get('/party-api/v1/businesses/id/{}'.format(id),
                                    query_string=query_string,
                                    headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def get_business_by_ref(self, ref, expected_status=200, query_string={}):
+    def get_business_by_ref(self, ref, expected_status=200, query_string=None):
         response = self.client.get('/party-api/v1/businesses/ref/{}'.format(ref),
                                    query_string=query_string,
                                    headers=self.auth_headers)

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -96,13 +96,17 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def get_business_by_id(self, id, expected_status=200):
-        response = self.client.get('/party-api/v1/businesses/id/{}'.format(id), headers=self.auth_headers)
+    def get_business_by_id(self, id, expected_status=200, query_string={}):
+        response = self.client.get('/party-api/v1/businesses/id/{}'.format(id),
+                                   query_string=query_string,
+                                   headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def get_business_by_ref(self, ref, expected_status=200):
-        response = self.client.get('/party-api/v1/businesses/ref/{}'.format(ref), headers=self.auth_headers)
+    def get_business_by_ref(self, ref, expected_status=200, query_string={}):
+        response = self.client.get('/party-api/v1/businesses/ref/{}'.format(ref),
+                                   query_string=query_string,
+                                   headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -32,7 +32,18 @@ class TestParties(PartyTestClient):
         party_id = self.post_to_businesses(mock_business, 200)['id']
 
         response = self.get_business_by_id(party_id)
-        self.assertTrue(response.items() >= mock_business.items())
+        self.assertEqual(len(response.items()), 5)
+        self.assertEqual(response.get('id'), party_id)
+        self.assertEqual(response.get('name'), mock_business.get('name'))
+
+    def test_get_business_by_id_returns_correct_representation_verbose(self):
+        mock_business = MockBusiness() \
+            .attributes(source='test_get_business_by_id_returns_correct_representation_summary') \
+            .as_business()
+        party_id = self.post_to_businesses(mock_business, 200)['id']
+
+        response = self.get_business_by_id(party_id, query_string={"verbose": "true"})
+        self.assertTrue(len(response.items()) >= len(mock_business.items()))
 
     def test_get_business_by_ref_returns_correct_representation(self):
         mock_business = MockBusiness() \
@@ -41,6 +52,17 @@ class TestParties(PartyTestClient):
         self.post_to_businesses(mock_business, 200)
 
         response = self.get_business_by_ref(mock_business['sampleUnitRef'])
+        self.assertEqual(len(response.items()), 5)
+        self.assertEqual(response.get('sampleUnitRef'), mock_business['sampleUnitRef'])
+        self.assertEqual(response.get('name'), mock_business.get('name'))
+
+    def test_get_business_by_ref_returns_correct_representation_verbose(self):
+        mock_business = MockBusiness() \
+            .attributes(source='test_get_business_by_ref_returns_correct_representation') \
+            .as_business()
+        self.post_to_businesses(mock_business, 200)
+
+        response = self.get_business_by_ref(mock_business['sampleUnitRef'], query_string={"verbose": "true"})
         for x in mock_business:
             self.assertTrue(x in response)
 


### PR DESCRIPTION
Link to trello: https://trello.com/c/0goz2j83/710-tbl098-p3-verbose-business-party

Changes made:
-  Default GET requests to /businesses/ref/<ref> and /businesses/id/<id> endpoints now return a summary of business details
- Added 'verbose' param to the endpoints. ?verbose=true returns all business details
- Changed JSON structure for GET /parties/type/<sampleUnitType> endpoints to return 'name' on the outer layer instead within the 'attributes' key (It will still be there too, for the time being)