### PR TITLE
Add manifest for cloudfoundry deployments

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,11 @@
+applications:
+- name: ras-party-service
+  disk_quota: 1G
+  health-check-http-endpoint: /info
+  health-check-type: http
+  instances: 1
+  memory: 512M
+  services:
+  - ras-party-db
+  stack: cflinuxfs2
+  timeout: 180


### PR DESCRIPTION
Add manifest file for cloudfoundry deployments

1. Are the defaults set to sensible values?
1. Are we missing any manifest properties that should be there?
1. Could we strip them down further?