### PR TITLE
[Defect 71] Change all respondents queries to be case insensitive

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py36
 
 [testenv]
 deps=-r{toxinidir}/requirements.txt


### PR DESCRIPTION
Refactored all email queries out into separate method which does a case insensitive query. Tests are to assert this functionality is used. Initially I intended to make sure the query was case insensitive by mocking the sqlalchemy session but the comparator appears to not implement equality checks