### PR TITLE
[Tbl3] separate tests for respondents

### DIFF
--- a/test/party_client.py
+++ b/test/party_client.py
@@ -136,9 +136,9 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def request_password_change(self, email, expected_status=200):
+    def request_password_change(self, payload, expected_status=200):
         response = self.client.post('/party-api/v1/respondents/request_password_change',
-                                    data=json.dumps({'email_address': email}),
+                                    data=json.dumps(payload),
                                     headers=self.auth_headers,
                                     content_type='application/vnd.ons.business+json')
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -125,6 +125,11 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
+    def get_respondent_by_email(self, email, expected_status=200):
+        response = self.client.get('/party-api/v1/respondents/email/{}'.format(email), headers=self.auth_headers)
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))
+
     def put_email_verification(self, token, expected_status):
         response = self.client.put('/party-api/v1/emailverification/{}'.format(token), headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -11,6 +11,7 @@ from ras_party.models.models import Business, Respondent, BusinessRespondent, En
 from run import create_app, initialise_db
 from test.fixtures import party_schema
 from test.fixtures.config import test_config
+from test.mocks import MockBusiness, MockRespondent
 
 
 def businesses():
@@ -40,6 +41,15 @@ class PartyTestClient(TestCase):
         app.config['PARTY_SCHEMA'] = party_schema.schema
         initialise_db(app)
         return app
+
+    def populate_with_business(self):
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+
+    def populate_with_respondent(self):
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        self.post_to_respondents(mock_respondent, 200)
 
     @property
     def auth_headers(self):

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -11,7 +11,7 @@ from ras_party.models.models import Business, Respondent, BusinessRespondent, En
 from run import create_app, initialise_db
 from test.fixtures import party_schema
 from test.fixtures.config import test_config
-from test.mocks import MockBusiness, MockRespondent
+from test.mocks import MockBusiness
 
 
 def businesses():
@@ -46,10 +46,6 @@ class PartyTestClient(TestCase):
         mock_business = MockBusiness().as_business()
         mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
         self.post_to_businesses(mock_business, 200)
-
-    def populate_with_respondent(self):
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
 
     @property
     def auth_headers(self):

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -86,7 +86,7 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def put_email_to_respondents(self, payload, expected_status):
+    def put_email_to_respondents(self, payload, expected_status=200):
         response = self.client.put('/party-api/v1/respondents/email',
                                    headers=self.auth_headers,
                                    data=json.dumps(payload),

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -1,16 +1,8 @@
 import uuid
-from unittest.mock import MagicMock, patch
 
-from flask import current_app
-from itsdangerous import URLSafeTimedSerializer
-
-from ras_common_utils.ras_error.ras_error import RasError
-from ras_party.controllers import account_controller
-from ras_party.support.public_website import PublicWebsite
 from ras_party.support.requests_wrapper import Requests
-from ras_party.support.verification import generate_email_token
-from test.mocks import MockBusiness, MockRequests, MockResponse
-from test.party_client import PartyTestClient, businesses, enrolments
+from test.mocks import MockBusiness, MockRequests
+from test.party_client import PartyTestClient, businesses
 
 
 class TestParties(PartyTestClient):
@@ -150,8 +142,6 @@ class TestParties(PartyTestClient):
 
     def test_get_party_with_nonexistent_ref(self):
         self.get_party_by_ref('B', '123', 404)
-
-
 
 
 if __name__ == '__main__':

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -6,12 +6,11 @@ from itsdangerous import URLSafeTimedSerializer
 
 from ras_common_utils.ras_error.ras_error import RasError
 from ras_party.controllers import account_controller
-from ras_party.models.models import RespondentStatus, Respondent
 from ras_party.support.public_website import PublicWebsite
 from ras_party.support.requests_wrapper import Requests
 from ras_party.support.verification import generate_email_token
-from test.mocks import MockBusiness, MockRespondent, MockRequests, MockResponse
-from test.party_client import PartyTestClient, businesses, respondents, business_respondent_associations, enrolments
+from test.mocks import MockBusiness, MockRequests, MockResponse
+from test.party_client import PartyTestClient, businesses, enrolments
 
 
 class TestParties(PartyTestClient):
@@ -21,8 +20,14 @@ class TestParties(PartyTestClient):
         Requests._lib = self.mock_requests
 
     def test_post_valid_business_adds_to_db(self):
-        mock_business = MockBusiness().attributes(source='test_post_valid_party_adds_to_db').as_business()
+        mock_business = MockBusiness().attributes(source='test_post_valid_business_adds_to_db').as_business()
         self.post_to_businesses(mock_business, 200)
+
+        self.assertEqual(len(businesses()), 1)
+
+    def test_post_valid_party_adds_to_db(self):
+        mock_party = MockBusiness().attributes(source='test_post_valid_party_adds_to_db').as_party()
+        self.post_to_parties(mock_party, 200)
 
         self.assertEqual(len(businesses()), 1)
 
@@ -67,52 +72,6 @@ class TestParties(PartyTestClient):
         for x in mock_business:
             self.assertTrue(x in response)
 
-    def test_post_valid_respondent_adds_to_db(self):
-        # Given the database contains no respondents
-        self.assertEqual(len(respondents()), 0)
-        # And there is a business (related to the IAC code case context)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
-        # Then the database contains a respondent
-        self.assertEqual(len(respondents()), 1)
-
-    def test_get_respondent_by_id_returns_correct_representation(self):
-        # Given there is a business (related to the IAC code case context)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        resp = self.post_to_respondents(mock_respondent, 200)
-        party_id = resp['id']
-        # And we get the new respondent
-        response = self.get_respondent_by_id(party_id)
-
-        # Not expecting the enrolmentCode to be returned as part of the respondent
-        del mock_respondent['enrolmentCode']
-        # Then the response matches the posted respondent
-        self.assertTrue('id' in response)
-        self.assertEqual(response['emailAddress'], mock_respondent['emailAddress'])
-        self.assertEqual(response['firstName'], mock_respondent['firstName'])
-        self.assertEqual(response['lastName'], mock_respondent['lastName'])
-        self.assertEqual(response['sampleUnitType'], mock_respondent['sampleUnitType'])
-        self.assertEqual(response['telephone'], mock_respondent['telephone'])
-
-    def test_post_valid_party_adds_to_db(self):
-        mock_party = MockBusiness().attributes(source='test_post_valid_party_adds_to_db').as_party()
-
-        self.post_to_parties(mock_party, 200)
-        self.assertEqual(len(businesses()), 1)
-
-        mock_party = MockRespondent().attributes().as_respondent()
-
-        self.post_to_parties(mock_party, 400)
-        self.assertEqual(len(businesses()), 1)
-
     def test_get_party_by_id_returns_correct_representation(self):
         mock_party_b = MockBusiness() \
             .attributes(source='test_get_party_by_id_returns_correct_representation') \
@@ -147,7 +106,7 @@ class TestParties(PartyTestClient):
 
     def test_existing_party_can_be_updated(self):
         mock_party = MockBusiness() \
-            .attributes(source='test_existing_respondent_can_be_updated', version=1)
+            .attributes(source='test_existing_party_can_be_updated', version=1)
 
         response_1 = self.post_to_parties(mock_party.as_party(), 200)
         self.assertEqual(len(businesses()), 1)
@@ -158,189 +117,17 @@ class TestParties(PartyTestClient):
         self.assertEqual(len(businesses()), 1)
         self.assertEqual(response_2['attributes']['version'], 2)
 
-    def test_post_respondent_with_inactive_iac(self):
-        # Given the IAC code is inactive
-        def mock_get_iac(*args, **kwargs):
-            return MockResponse('{"active": false}')
-        self.mock_requests.get = mock_get_iac
-        # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        # Then status code 400 is returned
-        self.post_to_respondents(mock_respondent, 400)
-
-    def test_post_respondent_requests_the_iac_details(self):
-        # Given there is a business (related to the IAC code case context)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
-        # Then the case service is called with the supplied IAC code
-        self.mock_requests.get.assert_called_once_with('http://mockhost:1111/cases/iac/fb747cq725lj')
-
-    def test_put_respondent_email_returns_400_when_no_email(self):
-        self.put_email_to_respondents({}, 400)
-
-    def test_put_respondent_email_changes_email(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
-        self.assertNotEqual("test@test.test", mock_respondent['emailAddress'])
-        put_data = {
-            "email_address": mock_respondent['emailAddress'],
-            "new_email_address": "test@test.test"
-        }
-        self.put_email_to_respondents(put_data, 200)
-        respondent = respondents()[0]
-        self.assertEqual("test@test.test", respondent.email_address)
-
-    def test_put_respondent_email_calls_the_notify_service(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-
-        self.assertTrue(mock_notify.call_count == 0)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
-        self.assertEqual(mock_notify.verify_email.call_count, 1)
-        put_data = {
-            "email_address": mock_respondent['emailAddress'],
-            "new_email_address": "test@test.test"
-        }
-        self.put_email_to_respondents(put_data, 200)
-        self.assertEqual(mock_notify.verify_email.call_count, 2)
-
-    def test_post_respondent_creates_the_business_respondent_association(self):
-        # Given the database contains no associations
-        self.assertEqual(len(business_respondent_associations()), 0)
-        # And there is a business (related to the IAC code case context)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        created_respondent = self.post_to_respondents(mock_respondent, 200)
-        # Then the database contains an association
-        self.assertEqual(len(business_respondent_associations()), 1)
-        # And the association is between the given business and respondent
-        assoc = business_respondent_associations()[0]
-        business_id = assoc.business_id
-        respondent_id = assoc.respondent.party_uuid
-        self.assertEqual(str(business_id), '3b136c4b-7a14-4904-9e01-13364dd7b972')
-        self.assertEqual(str(respondent_id), created_respondent['id'])
-
-    def test_post_respondent_creates_the_enrolment(self):
-        # Given the database contains no enrolments
-        self.assertEqual(len(enrolments()), 0)
-        # And there is a business (related to the IAC code case context)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        created_respondent = self.post_to_respondents(mock_respondent, 200)
-        # Then the database contains an association
-        self.assertEqual(len(enrolments()), 1)
-        enrolment = enrolments()[0]
-        # And the enrolment contains the survey id given in the survey fixture
-        self.assertEqual(str(enrolment.survey_id), 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87')
-        # And is linked to the created respondent
-        self.assertEqual(str(enrolment.business_respondent.respondent.party_uuid),
-                         created_respondent['id'])
-        # And is linked to the given business
-        self.assertEqual(str(enrolment.business_respondent.business.party_uuid),
-                         '3b136c4b-7a14-4904-9e01-13364dd7b972')
-
-    def test_post_respondent_calls_the_notify_service(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        # Given there is a business
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        # And an associated respondent
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        # When a new respondent is posted
-        self.post_to_respondents(mock_respondent, 200)
-        # Then the (mock) notify service is called
-        self.assertTrue(mock_notify.verify_email.called)
-        self.assertTrue(mock_notify.verify_email.call_count == 1)
-
-    def test_email_verification_activates_a_respondent(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        # Given there is a business and an associated respondent
-        self.populate_with_business_and_respondent()
-
-        # And the respondent state is CREATED
-        db_respondent = respondents()[0]
-        self.assertEqual(db_respondent.status, RespondentStatus.CREATED)
-        # When the email is verified
-        # TODO: this is an awful way of discovering the token, needs to be cleaned-up:
-        frontstage_url = mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
-        token = frontstage_url.split('/')[-1]
-        self.put_email_verification(token, 200)
-        # Then the respondent state is ACTIVE
-        db_respondent = respondents()[0]
-        self.assertEqual(db_respondent.status, RespondentStatus.ACTIVE)
-
-    def test_email_verification_url_is_from_config_yml_file(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        # Given there is a business and an associated respondent
-        self.populate_with_business_and_respondent()
-
-        # And the respondent state is CREATED
-        db_respondent = respondents()[0]
-        self.assertEqual(db_respondent.status, RespondentStatus.CREATED)
-
-        expected_url = 'http://dummy.ons.gov.uk/register/activate-account/'
-
-        # When the email is verified get the email URL from the argument list in the '_send_message_to_gov_uk_notify'
-        # method then check the URL is the same as the value configured in the config file
-        frontstage_url = mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
-        self.assertIn(expected_url, frontstage_url)
-
-    def test_email_verification_twice_produces_a_200(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        # Given there is a business and an associated respondent
-        self.populate_with_business_and_respondent()
-
-        # When the email is verified twice
-        frontstage_url = mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
-        token = frontstage_url.split('/')[-1]
-
-        self.put_email_verification(token, 200)
-        # Then the response is a 200
-        self.put_email_verification(token, 200)
-
-    def test_email_verification_unknown_token_produces_a_404(self, *_):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-
-        # When an unknown email token exists
-        secret_key = "aardvark"
-        timed_serializer = URLSafeTimedSerializer(secret_key)
-        token = timed_serializer.dumps("brucie@tv.com", salt='bulbous')
-        # Then the response is a 404
-        self.put_email_verification(token, 404)
-
-    def test_post_respondent_with_no_body_returns_400(self):
-        self.post_to_respondents(None, 400)
-
-    def test_post_business_with_no_body_returns_400(self):
+    def test_post_businesses_with_no_body_returns_400(self):
         self.post_to_businesses(None, 400)
 
     def test_post_party_with_no_body_returns_400(self):
         self.post_to_parties(None, 400)
+
+    def test_post_party_with_bad_schema_returns_400(self):
+        self.post_to_parties({'bad': 'schema'}, 400)
+
+    def test_post_businesses_with_bad_schema_returns_400(self):
+        self.post_to_businesses({'bad': 'schema'}, 400)
 
     def test_get_business_with_invalid_id(self):
         self.get_business_by_id('123', 400)
@@ -364,216 +151,7 @@ class TestParties(PartyTestClient):
     def test_get_party_with_nonexistent_ref(self):
         self.get_party_by_ref('B', '123', 404)
 
-    def test_get_respondent_with_invalid_id(self):
-        self.get_respondent_by_id('123', 400)
 
-    def test_resend_verification_email(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-
-        # Given there is a business and respondent
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        resp = self.post_to_respondents(mock_respondent, 200)
-
-        # When the resend verification end point is hit
-        self.resend_verification_email(resp['id'], 200)
-
-    def test_resend_verification_email_party_id_not_found(self):
-        # Given the party_id sent doesn't exist
-        # When the resend verification end point is hit
-        response = self.resend_verification_email('3b136c4b-7a14-4904-9e01-13364dd7b972', 404)
-
-        # Then an email is not sent and a message saying there is no respondent is returned
-        self.assertIn(account_controller.NO_RESPONDENT_FOR_PARTY_ID, response['errors'])
-
-    def test_resend_verification_email_party_id_malformed(self):
-        self.resend_verification_email('malformed', 500)
-
-    def test_request_password_change_calls_notify_gateway(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        # Given there is a business and a respondent
-        self.populate_with_business_and_respondent()
-
-        # when the request password end point is hit
-        self.request_password_change(email='a@z.com')
-
-        # then a notification message is sent to the notify gateway
-        self.assertTrue(mock_notify.verify_email.called)
-        self.assertEqual(mock_notify.request_password_change.call_count, 1)
-
-    def test_change_password_with_incorrect_token(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        # Given there is a business and a respondent
-        self.populate_with_business_and_respondent()
-
-        # when the password is changed with an incorrect token
-        token = "fake_token"
-        payload = {
-            "new_password": "password",
-            "token": token
-        }
-
-        # it produces a 404
-        self.change_password(token, payload, expected_status=404)
-
-    def test_change_respondent_with_valid_token(self):
-        # Given a valid token
-        token = self.generate_valid_token()
-        payload = {
-            "new_password": "password",
-            "token": token
-        }
-        # When the password is
-        self.change_password(token, payload, expected_status=200)
-
-    def test_verify_token_with_bad_token(self):
-        # given a bad token
-        secret_key = "fake_key"
-        timed_serializer = URLSafeTimedSerializer(secret_key)
-        token = timed_serializer.dumps("brucie@tv.com", salt='bulbous')
-
-        # when the verify token endpoint is hit it errors
-        self.verify_token(token, expected_status=404)
-
-    def test_verify_token_with_valid_token(self):
-        # given a valid token
-        token = self.generate_valid_token()
-
-        # the verify end point verifies the token
-        self.verify_token(token, expected_status=200)
-
-    def populate_with_business_and_respondent(self):
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
-
-    def generate_valid_token(self):
-        # ugly way to generate token taken from previous tests
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-        self.populate_with_business_and_respondent()
-        frontstage_url = mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
-        token = frontstage_url.split('/')[-1]
-        return token
-
-    def test_should_reset_password_when_email_wrong_case(self):
-        # Given
-        # Create respondent
-        respondent = Respondent()
-        respondent.email_address = 'john@example.com'
-        current_app.db.session.add(respondent)
-        current_app.db.session.commit()
-
-        # Mock notification
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
-
-        # When
-        self.request_password_change('John@example.com', expected_status=200)
-
-        # Then
-        personalisation = {
-            'RESET_PASSWORD_URL': PublicWebsite(current_app.config).reset_password_url(respondent.email_address),
-            'FIRST_NAME': respondent.first_name
-        }
-        mock_notify.request_password_change.assert_called_once_with('john@example.com', personalisation, 'None')
-
-    @staticmethod
-    def test_verify_token_uses_case_insensitive_email_query():
-        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
-                patch('ras_party.support.session_decorator.current_app.db') as db:
-            # Given
-            token = generate_email_token('test@example.com', current_app.config)
-
-            # When
-            # pylint: disable=E1120
-            # session is injected by decorator
-            account_controller.verify_token(token)
-
-            # Then
-            query.assert_called_once_with('test@example.com', db.session())
-
-    @staticmethod
-    def test_change_respondent_password_uses_case_insensitive_email_query():
-        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
-                patch('ras_party.support.session_decorator.current_app.db') as db,\
-                patch('ras_party.controllers.account_controller.OauthClient') as client,\
-                patch('ras_party.controllers.account_controller.NotifyGateway'):
-            # Given
-            token = generate_email_token('test@example.com', current_app.config)
-            client().update_account().status_code = 201
-
-            # When
-            # pylint: disable=E1120
-            # session is injected by decorator
-            account_controller.change_respondent_password(token, {'new_password': 'abc'})
-
-            # Then
-            query.assert_called_once_with('test@example.com', db.session())
-
-    @staticmethod
-    def test_request_password_change_uses_case_insensitive_email_query():
-        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
-                patch('ras_party.support.session_decorator.current_app.db') as db,\
-                patch('ras_party.controllers.account_controller.NotifyGateway'),\
-                patch('ras_party.controllers.account_controller.PublicWebsite'):
-            # Given
-            payload = {'email_address': 'test@example.com'}
-
-            # When
-            # pylint: disable=E1120
-            # session is injected by decorator
-            account_controller.request_password_change(payload)
-
-            # Then
-            query.assert_called_once_with('test@example.com', db.session())
-
-    def test_post_respondent_uses_case_insensitive_email_query(self):
-        with patch('ras_party.controllers.queries.query_respondent_by_email') as query,\
-                patch('ras_party.support.session_decorator.current_app.db') as db,\
-                patch('ras_party.controllers.account_controller.NotifyGateway'),\
-                patch('ras_party.controllers.account_controller.Requests'):
-            # Given
-            payload = {
-                'emailAddress': 'test@example.com',
-                'firstName': 'Joe',
-                'lastName': 'bloggs',
-                'password': 'secure',
-                'telephone': '111',
-                'enrolmentCode': 'abc'
-            }
-            query('test@example.com', db.session()).return_value = None
-
-            # When
-            # pylint: disable=E1120
-            # session is injected by decorator
-            with self.assertRaises(RasError):
-                account_controller.post_respondent(payload)
-
-            # Then
-            query.assert_called_once_with('test@example.com', db.session())
-
-    @staticmethod
-    def test_put_email_verification_uses_case_insensitive_email_query():
-        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
-                patch('ras_party.support.session_decorator.current_app.db') as db:
-            # Given
-            token = generate_email_token('test@example.com', current_app.config)
-
-            # When
-            # pylint: disable=E1120
-            # session is injected by decorator
-            account_controller.put_email_verification(token)
-
-            # Then
-            query.assert_called_once_with('test@example.com', db.session())
 
 
 if __name__ == '__main__':

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -414,13 +414,6 @@ class TestRespondents(PartyTestClient):
     def test_post_respondent_with_no_payload_returns_400(self):
         self.post_to_respondents(None, 400)
 
-    def test_post_business_with_payload_returns_200(self):
-        mock_business = MockBusiness().attributes().as_business()
-        self.post_to_businesses(mock_business, 200)
-
-    def test_post_business_with_no_payload_returns_400(self):
-        self.post_to_businesses(None, 400)
-
     def test_post_respondent_with_inactive_iac(self):
         # Given the IAC code is inactive
         def mock_get_iac(*args, **kwargs):

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-value-for-parameter
+# pylint: disable=no-value-for-parameter
 
 import uuid
 from unittest.mock import MagicMock, patch

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -403,13 +403,10 @@ class TestRespondents(PartyTestClient):
             query.assert_called_once_with('test@example.test', db.session())
 
     def test_post_respondent_with_payload_returns_200(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
         mock_business = MockBusiness().as_business()
         mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
         self.post_to_businesses(mock_business, 200)
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
+        self.post_to_respondents(self.mock_respondent, 200)
 
     def test_post_respondent_with_no_payload_returns_400(self):
         self.post_to_respondents(None, 400)
@@ -420,9 +417,8 @@ class TestRespondents(PartyTestClient):
             return MockResponse('{"active": false}')
         self.mock_requests.get = mock_get_iac
         # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
         # Then status code 400 is returned
-        self.post_to_respondents(mock_respondent, 400)
+        self.post_to_respondents(self.mock_respondent, 400)
 
     def test_post_respondent_requests_the_iac_details(self):
         # Given there is a business (related to the IAC code case context)
@@ -430,8 +426,7 @@ class TestRespondents(PartyTestClient):
         mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
         self.post_to_businesses(mock_business, 200)
         # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
+        self.post_to_respondents(self.mock_respondent, 200)
         # Then the case service is called with the supplied IAC code
         self.mock_requests.get.assert_called_once_with('http://mockhost:1111/cases/iac/fb747cq725lj')
 
@@ -443,8 +438,7 @@ class TestRespondents(PartyTestClient):
         mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
         self.post_to_businesses(mock_business, 200)
         # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        self.post_to_respondents(mock_respondent, 200)
+        self.post_to_respondents(self.mock_respondent, 200)
         # Then the database contains a respondent
         self.assertEqual(len(respondents()), 1)
 
@@ -456,8 +450,7 @@ class TestRespondents(PartyTestClient):
         mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
         self.post_to_businesses(mock_business, 200)
         # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        created_respondent = self.post_to_respondents(mock_respondent, 200)
+        created_respondent = self.post_to_respondents(self.mock_respondent, 200)
         # Then the database contains an association
         self.assertEqual(len(business_respondent_associations()), 1)
         # And the association is between the given business and respondent
@@ -475,8 +468,7 @@ class TestRespondents(PartyTestClient):
         mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
         self.post_to_businesses(mock_business, 200)
         # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        created_respondent = self.post_to_respondents(mock_respondent, 200)
+        created_respondent = self.post_to_respondents(self.mock_respondent, 200)
         # Then the database contains an association
         self.assertEqual(len(enrolments()), 1)
         enrolment = enrolments()[0]
@@ -490,19 +482,15 @@ class TestRespondents(PartyTestClient):
                          '3b136c4b-7a14-4904-9e01-13364dd7b972')
 
     def test_post_respondent_calls_the_notify_service(self):
-        mock_notify = MagicMock()
-        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
         # Given there is a business
         mock_business = MockBusiness().as_business()
         mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
         self.post_to_businesses(mock_business, 200)
-        # And an associated respondent
-        mock_respondent = MockRespondent().attributes().as_respondent()
         # When a new respondent is posted
-        self.post_to_respondents(mock_respondent, 200)
+        self.post_to_respondents(self.mock_respondent, 200)
         # Then the (mock) notify service is called
-        self.assertTrue(mock_notify.verify_email.called)
-        self.assertTrue(mock_notify.verify_email.call_count == 1)
+        self.assertTrue(self.mock_notify.verify_email.called)
+        self.assertTrue(self.mock_notify.verify_email.call_count == 1)
 
     def test_post_respondent_uses_case_insensitive_email_query(self):
         with patch('ras_party.controllers.queries.query_respondent_by_email') as query,\

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -402,8 +402,24 @@ class TestRespondents(PartyTestClient):
             account_controller.put_email_verification(token)
             query.assert_called_once_with('test@example.test', db.session())
 
-    def test_post_respondent_with_no_body_returns_400(self):
+    def test_post_respondent_with_payload_returns_200(self):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        self.post_to_respondents(mock_respondent, 200)
+
+    def test_post_respondent_with_no_payload_returns_400(self):
         self.post_to_respondents(None, 400)
+
+    def test_post_business_with_payload_returns_200(self):
+        mock_business = MockBusiness().attributes().as_business()
+        self.post_to_businesses(mock_business, 200)
+
+    def test_post_business_with_no_payload_returns_400(self):
+        self.post_to_businesses(None, 400)
 
     def test_post_respondent_with_inactive_iac(self):
         # Given the IAC code is inactive

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -56,6 +56,24 @@ class TestRespondents(PartyTestClient):
     def test_get_respondent_with_invalid_id(self):
         self.get_respondent_by_id('123', 400)
 
+    def test_get_respondent_with_valid_id(self):
+        self.get_respondent_by_id(str(uuid.uuid4()), 404)
+
+    def test_get_respondent_by_id_returns_correct_representation(self):
+        # Given there is a respondent in the db
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+
+        # And we get the new respondent
+        response = self.get_respondent_by_id(respondent.party_uuid)
+
+        # Then the response matches the posted respondent
+        self.assertTrue('id' in response)
+        self.assertEqual(response['emailAddress'], self.mock_respondent['emailAddress'])
+        self.assertEqual(response['firstName'], self.mock_respondent['firstName'])
+        self.assertEqual(response['lastName'], self.mock_respondent['lastName'])
+        self.assertEqual(response['sampleUnitType'], self.mock_respondent['sampleUnitType'])
+        self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
+
     def test_resend_verification_email(self):
         # Given there is a respondent
         respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
@@ -316,28 +334,6 @@ class TestRespondents(PartyTestClient):
 
             # Then
             query.assert_called_once_with('test@example.com', db.session())
-
-    def test_get_respondent_by_id_returns_correct_representation(self):
-        # Given there is a business (related to the IAC code case context)
-        mock_business = MockBusiness().as_business()
-        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
-        self.post_to_businesses(mock_business, 200)
-        # When a new respondent is posted
-        mock_respondent = MockRespondent().attributes().as_respondent()
-        resp = self.post_to_respondents(mock_respondent, 200)
-        party_id = resp['id']
-        # And we get the new respondent
-        response = self.get_respondent_by_id(party_id)
-
-        # Not expecting the enrolmentCode to be returned as part of the respondent
-        del mock_respondent['enrolmentCode']
-        # Then the response matches the posted respondent
-        self.assertTrue('id' in response)
-        self.assertEqual(response['emailAddress'], mock_respondent['emailAddress'])
-        self.assertEqual(response['firstName'], mock_respondent['firstName'])
-        self.assertEqual(response['lastName'], mock_respondent['lastName'])
-        self.assertEqual(response['sampleUnitType'], mock_respondent['sampleUnitType'])
-        self.assertEqual(response['telephone'], mock_respondent['telephone'])
 
     def test_put_respondent_email_returns_400_when_no_email(self):
         self.put_email_to_respondents({}, 400)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -448,13 +448,10 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['status'], RespondentStatus.ACTIVE.name)
 
     def test_email_verification_bad_token_produces_a_404(self):
-        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
         secret_key = "fake_key"
         timed_serializer = URLSafeTimedSerializer(secret_key)
-        token = timed_serializer.dumps(respondent.email_address, salt='salt')
+        token = timed_serializer.dumps(self.mock_respondent['emailAddress'], salt='salt')
         self.put_email_verification(token, 404)
-        db_respondent = respondents()[0]
-        self.assertEqual(db_respondent.status, RespondentStatus.CREATED)
 
     def test_email_verification_unknown_email_produces_a_404(self):
         self.add_respondent_to_db_and_oauth(self.mock_respondent)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -47,7 +47,7 @@ class TestRespondents(PartyTestClient):
         return self.respondent
 
     @staticmethod
-    def generate_valid_token_from_email(self, email):
+    def generate_valid_token_from_email(email):
         frontstage_url = PublicWebsite(current_app.config).activate_account_url(email)
         return frontstage_url.split('/')[-1]
 

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -173,7 +173,7 @@ class TestRespondents(PartyTestClient):
         self.add_respondent_to_db_and_oauth(self.mock_respondent)
 
         # when the request password end point is hit
-        payload = {'email_address': 'not-mock@example.com'}
+        payload = {'email_address': 'not-mock@example.test'}
         self.request_password_change(payload, expected_status=404)
         self.assertFalse(self.mock_notify.request_password_change.called)
 
@@ -208,7 +208,7 @@ class TestRespondents(PartyTestClient):
                 patch('ras_party.controllers.account_controller.NotifyGateway'),\
                 patch('ras_party.controllers.account_controller.PublicWebsite'):
             # Given
-            payload = {'email_address': 'test@example.com'}
+            payload = {'email_address': 'test@example.test'}
 
             # When
             # pylint: disable=E1120
@@ -216,7 +216,7 @@ class TestRespondents(PartyTestClient):
             account_controller.request_password_change(payload)
 
             # Then
-            query.assert_called_once_with('test@example.com', db.session())
+            query.assert_called_once_with('test@example.test', db.session())
 
     def test_change_password_with_invalid_token(self):
         # when the password is changed with an incorrect token
@@ -305,7 +305,7 @@ class TestRespondents(PartyTestClient):
                 patch('ras_party.controllers.account_controller.OauthClient') as client,\
                 patch('ras_party.controllers.account_controller.NotifyGateway'):
             # Given
-            token = generate_email_token('test@example.com', current_app.config)
+            token = generate_email_token('test@example.test', current_app.config)
             client().update_account().status_code = 201
 
             # When
@@ -467,7 +467,7 @@ class TestRespondents(PartyTestClient):
         with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
                 patch('ras_party.support.session_decorator.current_app.db') as db:
             # Given
-            token = self.generate_valid_token_from_email('test@example.com')
+            token = self.generate_valid_token_from_email('test@example.test')
 
             # When
             # pylint: disable=E1120
@@ -475,7 +475,7 @@ class TestRespondents(PartyTestClient):
             account_controller.put_email_verification(token)
 
             # Then
-            query.assert_called_once_with('test@example.com', db.session())
+            query.assert_called_once_with('test@example.test', db.session())
 
     def test_post_respondent_with_no_body_returns_400(self):
         self.post_to_respondents(None, 400)
@@ -577,14 +577,14 @@ class TestRespondents(PartyTestClient):
                 patch('ras_party.controllers.account_controller.Requests'):
             # Given
             payload = {
-                'emailAddress': 'test@example.com',
+                'emailAddress': 'test@example.test',
                 'firstName': 'Joe',
                 'lastName': 'bloggs',
                 'password': 'secure',
                 'telephone': '111',
                 'enrolmentCode': 'abc'
             }
-            query('test@example.com', db.session()).return_value = None
+            query('test@example.test', db.session()).return_value = None
 
             # When
             # pylint: disable=E1120
@@ -593,4 +593,4 @@ class TestRespondents(PartyTestClient):
                 account_controller.post_respondent(payload)
 
             # Then
-            query.assert_called_once_with('test@example.com', db.session())
+            query.assert_called_once_with('test@example.test', db.session())

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -74,6 +74,27 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['sampleUnitType'], self.mock_respondent['sampleUnitType'])
         self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
 
+    def test_get_respondent_with_invalid_email(self):
+        self.get_respondent_by_email('123', 404)
+
+    def test_get_respondent_with_valid_email(self):
+        self.get_respondent_by_email('test@example.test', 404)
+
+    def test_get_respondent_by_email_returns_correct_representation(self):
+        # Given there is a respondent in the db
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+
+        # And we get the new respondent
+        response = self.get_respondent_by_email(respondent.email_address)
+
+        # Then the response matches the posted respondent
+        self.assertTrue('id' in response)
+        self.assertEqual(response['emailAddress'], self.mock_respondent['emailAddress'])
+        self.assertEqual(response['firstName'], self.mock_respondent['firstName'])
+        self.assertEqual(response['lastName'], self.mock_respondent['lastName'])
+        self.assertEqual(response['sampleUnitType'], self.mock_respondent['sampleUnitType'])
+        self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
+
     def test_resend_verification_email(self):
         # Given there is a respondent
         respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1,0 +1,488 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from flask import current_app
+from itsdangerous import URLSafeTimedSerializer
+
+from ras_common_utils.ras_error.ras_error import RasError
+from ras_party.controllers import account_controller
+from ras_party.models.models import RespondentStatus, Respondent
+from ras_party.support.public_website import PublicWebsite
+from ras_party.support.requests_wrapper import Requests
+from ras_party.support.session_decorator import with_db_session
+from ras_party.support.transactional import transactional
+from ras_party.support.verification import generate_email_token
+from test.mocks import MockBusiness, MockRespondent, MockRequests, MockResponse
+from test.party_client import PartyTestClient, businesses, respondents, business_respondent_associations, enrolments
+
+
+class TestRespondents(PartyTestClient):
+
+    def setUp(self):
+        self.assertEqual(len(respondents()), 0)
+        self.mock_requests = MockRequests()
+        Requests._lib = self.mock_requests
+        self.mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=self.mock_notify)
+        self.mock_respondent = MockRespondent().attributes().as_respondent()
+        self.respondent = None
+
+    @with_db_session
+    def tearDown(self, session):
+        if self.respondent:
+            session.delete(self.respondent)
+
+    def generate_valid_token_from_email(self, email):
+        frontstage_url = PublicWebsite(current_app.config).activate_account_url(email)
+        token = frontstage_url.split('/')[-1]
+        return token
+
+    @transactional
+    @with_db_session
+    def add_respondent_to_db_and_oauth(self, party, tran, session):
+        translated_party = {
+            'party_uuid': party.get('id') or str(uuid.uuid4()),
+            'email_address': party['emailAddress'],
+            'first_name': party['firstName'],
+            'last_name': party['lastName'],
+            'telephone': party['telephone'],
+            'status': RespondentStatus.CREATED
+        }
+        self.respondent = Respondent(**translated_party)
+        session.add(self.respondent)
+        account_controller.register_user(party, tran)
+        return self.respondent
+
+    def test_get_respondent_with_invalid_id(self):
+        self.get_respondent_by_id('123', 400)
+
+    def test_resend_verification_email(self):
+        # Given there is a respondent
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+        # When the resend verification end point is hit
+        self.resend_verification_email(respondent.party_uuid, 200)
+
+    def test_resend_verification_email_calls_notify_gateway(self):
+        # Given there is a respondent
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+        # When the resend verification end point is hit
+        self.resend_verification_email(respondent.party_uuid, 200)
+        # Verification email is sent
+        self.assertEqual(self.mock_notify.verify_email.call_count, 1)
+
+    def test_resend_verification_email_party_id_not_found(self):
+        # Given the party_id sent doesn't exist
+        # When the resend verification end point is hit
+        response = self.resend_verification_email('3b136c4b-7a14-4904-9e01-13364dd7b972', 404)
+
+        # Then an email is not sent and a message saying there is no respondent is returned
+        self.assertIn(account_controller.NO_RESPONDENT_FOR_PARTY_ID, response['errors'])
+
+    def test_resend_verification_email_party_id_malformed(self):
+        self.resend_verification_email('malformed', 500)
+
+    def test_request_password_change_calls_notify_gateway(self):
+        # Given there is a respondent
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+
+        # when the request password end point is hit
+        self.request_password_change(email=respondent.email_address)
+
+        # then a notification message is sent to the notify gateway
+        self.assertEqual(self.mock_notify.request_password_change.call_count, 1)
+
+    def test_should_reset_password_when_email_wrong_case(self):
+        # Given
+        # Create respondent
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+
+        # When
+        self.request_password_change(respondent.email_address.upper())
+
+        # Then
+        personalisation = {
+            'RESET_PASSWORD_URL': PublicWebsite(current_app.config).reset_password_url(respondent.email_address),
+            'FIRST_NAME': respondent.first_name
+        }
+        self.mock_notify.request_password_change.assert_called_once_with(respondent.email_address, personalisation, respondent.party_uuid)
+
+    def test_change_password_with_invalid_token(self):
+        # when the password is changed with an incorrect token
+        token = "fake_token"
+        payload = {
+            "new_password": "password",
+            "token": token
+        }
+
+        # it produces a 404
+        self.change_password(token, payload, expected_status=404)
+
+    def test_change_password_with_no_password(self):
+        # when the password is changed with a valid token and no password
+        token = self.generate_valid_token_from_email('mock@email.com')
+        payload = {
+            # "new_password": "password",
+            "token": token
+        }
+
+        # it produces a 404
+        self.change_password(token, payload, expected_status=400)
+
+    def test_change_password_with_other_token(self):
+        # Given a respondent
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+
+        # when the password is changed with a token that does not match respondent
+        token = self.generate_valid_token_from_email('not-mock@email.com')
+        payload = {
+            "new_password": "password",
+            "token": token
+        }
+
+        # it produces a 404
+        self.change_password(token, payload, expected_status=404)
+
+    def test_change_password_with_no_respondent(self):
+        # when the password is changed with no respondents in db
+        token = self.generate_valid_token_from_email(self.mock_respondent['emailAddress'])
+        payload = {
+            "new_password": "password",
+            "token": token
+        }
+
+        # it produces a 404 (respondent not found)
+        self.change_password(token, payload, expected_status=404)
+
+    def test_change_password_with_valid_token(self):
+        # Given a valid token from the respondent
+        respondent = self.add_respondent_to_db_and_oauth(self.mock_respondent)
+        token = self.generate_valid_token_from_email(respondent.email_address)
+        payload = {
+            "new_password": "password",
+            "token": token
+        }
+        # When the password is
+        self.change_password(token, payload, expected_status=200)
+        personalisation = {
+            'FIRST_NAME': respondent.first_name
+        }
+        self.mock_notify.confirm_password_change.assert_called_once_with(respondent.email_address, personalisation, respondent.party_uuid)
+
+    def test_verify_token_with_bad_token(self):
+        # given a bad token
+        secret_key = "fake_key"
+        timed_serializer = URLSafeTimedSerializer(secret_key)
+        token = timed_serializer.dumps("brucie@tv.com", salt='bulbous')
+
+        # when the verify token endpoint is hit it errors
+        self.verify_token(token, expected_status=404)
+
+    def test_verify_token_with_valid_token(self):
+        # given a valid token
+        token = self.generate_valid_token()
+
+        # the verify end point verifies the token
+        self.verify_token(token, expected_status=200)
+
+    def test_post_valid_respondent_adds_to_db(self):
+        # Given the database contains no respondents
+        self.assertEqual(len(respondents()), 0)
+        # And there is a business (related to the IAC code case context)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        # When a new respondent is posted
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        self.post_to_respondents(mock_respondent, 200)
+        # Then the database contains a respondent
+        self.assertEqual(len(respondents()), 1)
+
+    def test_get_respondent_by_id_returns_correct_representation(self):
+        # Given there is a business (related to the IAC code case context)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        # When a new respondent is posted
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        resp = self.post_to_respondents(mock_respondent, 200)
+        party_id = resp['id']
+        # And we get the new respondent
+        response = self.get_respondent_by_id(party_id)
+
+        # Not expecting the enrolmentCode to be returned as part of the respondent
+        del mock_respondent['enrolmentCode']
+        # Then the response matches the posted respondent
+        self.assertTrue('id' in response)
+        self.assertEqual(response['emailAddress'], mock_respondent['emailAddress'])
+        self.assertEqual(response['firstName'], mock_respondent['firstName'])
+        self.assertEqual(response['lastName'], mock_respondent['lastName'])
+        self.assertEqual(response['sampleUnitType'], mock_respondent['sampleUnitType'])
+        self.assertEqual(response['telephone'], mock_respondent['telephone'])
+
+    def test_post_respondent_with_inactive_iac(self):
+        # Given the IAC code is inactive
+        def mock_get_iac(*args, **kwargs):
+            return MockResponse('{"active": false}')
+        self.mock_requests.get = mock_get_iac
+        # When a new respondent is posted
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        # Then status code 400 is returned
+        self.post_to_respondents(mock_respondent, 400)
+
+    def test_post_respondent_requests_the_iac_details(self):
+        # Given there is a business (related to the IAC code case context)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        # When a new respondent is posted
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        self.post_to_respondents(mock_respondent, 200)
+        # Then the case service is called with the supplied IAC code
+        self.mock_requests.get.assert_called_once_with('http://mockhost:1111/cases/iac/fb747cq725lj')
+
+    def test_put_respondent_email_returns_400_when_no_email(self):
+        self.put_email_to_respondents({}, 400)
+
+    def test_put_respondent_email_changes_email(self):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        self.post_to_respondents(mock_respondent, 200)
+        self.assertNotEqual("test@test.test", mock_respondent['emailAddress'])
+        put_data = {
+            "email_address": mock_respondent['emailAddress'],
+            "new_email_address": "test@test.test"
+        }
+        self.put_email_to_respondents(put_data, 200)
+        respondent = respondents()[0]
+        self.assertEqual("test@test.test", respondent.email_address)
+
+    def test_put_respondent_email_calls_the_notify_service(self):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+
+        self.assertTrue(mock_notify.call_count == 0)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        self.post_to_respondents(mock_respondent, 200)
+        self.assertEqual(mock_notify.verify_email.call_count, 1)
+        put_data = {
+            "email_address": mock_respondent['emailAddress'],
+            "new_email_address": "test@test.test"
+        }
+        self.put_email_to_respondents(put_data, 200)
+        self.assertEqual(mock_notify.verify_email.call_count, 2)
+
+    def test_post_respondent_creates_the_business_respondent_association(self):
+        # Given the database contains no associations
+        self.assertEqual(len(business_respondent_associations()), 0)
+        # And there is a business (related to the IAC code case context)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        # When a new respondent is posted
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        created_respondent = self.post_to_respondents(mock_respondent, 200)
+        # Then the database contains an association
+        self.assertEqual(len(business_respondent_associations()), 1)
+        # And the association is between the given business and respondent
+        assoc = business_respondent_associations()[0]
+        business_id = assoc.business_id
+        respondent_id = assoc.respondent.party_uuid
+        self.assertEqual(str(business_id), '3b136c4b-7a14-4904-9e01-13364dd7b972')
+        self.assertEqual(str(respondent_id), created_respondent['id'])
+
+    def test_post_respondent_creates_the_enrolment(self):
+        # Given the database contains no enrolments
+        self.assertEqual(len(enrolments()), 0)
+        # And there is a business (related to the IAC code case context)
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        # When a new respondent is posted
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        created_respondent = self.post_to_respondents(mock_respondent, 200)
+        # Then the database contains an association
+        self.assertEqual(len(enrolments()), 1)
+        enrolment = enrolments()[0]
+        # And the enrolment contains the survey id given in the survey fixture
+        self.assertEqual(str(enrolment.survey_id), 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87')
+        # And is linked to the created respondent
+        self.assertEqual(str(enrolment.business_respondent.respondent.party_uuid),
+                         created_respondent['id'])
+        # And is linked to the given business
+        self.assertEqual(str(enrolment.business_respondent.business.party_uuid),
+                         '3b136c4b-7a14-4904-9e01-13364dd7b972')
+
+    def test_post_respondent_calls_the_notify_service(self):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+        # Given there is a business
+        mock_business = MockBusiness().as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        # And an associated respondent
+        mock_respondent = MockRespondent().attributes().as_respondent()
+        # When a new respondent is posted
+        self.post_to_respondents(mock_respondent, 200)
+        # Then the (mock) notify service is called
+        self.assertTrue(mock_notify.verify_email.called)
+        self.assertTrue(mock_notify.verify_email.call_count == 1)
+
+    def test_email_verification_activates_a_respondent(self):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+        # Given there is a business and an associated respondent
+        self.populate_with_respondent()
+
+        # And the respondent state is CREATED
+        db_respondent = respondents()[0]
+        self.assertEqual(db_respondent.status, RespondentStatus.CREATED)
+        # When the email is verified
+        # TODO: this is an awful way of discovering the token, needs to be cleaned-up:
+        frontstage_url = mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
+        token = frontstage_url.split('/')[-1]
+        self.put_email_verification(token, 200)
+        # Then the respondent state is ACTIVE
+        db_respondent = respondents()[0]
+        self.assertEqual(db_respondent.status, RespondentStatus.ACTIVE)
+
+    def test_email_verification_url_is_from_config_yml_file(self):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+        # Given there is a business and an associated respondent
+        self.populate_with_respondent()
+
+        # And the respondent state is CREATED
+        db_respondent = respondents()[0]
+        self.assertEqual(db_respondent.status, RespondentStatus.CREATED)
+
+        expected_url = 'http://dummy.ons.gov.uk/register/activate-account/'
+
+        # When the email is verified get the email URL from the argument list in the '_send_message_to_gov_uk_notify'
+        # method then check the URL is the same as the value configured in the config file
+        frontstage_url = mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
+        self.assertIn(expected_url, frontstage_url)
+
+    def test_email_verification_twice_produces_a_200(self):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+        # Given there is a business and an associated respondent
+        self.populate_with_respondent()
+
+        # When the email is verified twice
+        frontstage_url = mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
+        token = frontstage_url.split('/')[-1]
+
+        self.put_email_verification(token, 200)
+        # Then the response is a 200
+        self.put_email_verification(token, 200)
+
+    def test_email_verification_unknown_token_produces_a_404(self, *_):
+        mock_notify = MagicMock()
+        account_controller.NotifyGateway = MagicMock(return_value=mock_notify)
+
+        # When an unknown email token exists
+        secret_key = "aardvark"
+        timed_serializer = URLSafeTimedSerializer(secret_key)
+        token = timed_serializer.dumps("brucie@tv.com", salt='bulbous')
+        # Then the response is a 404
+        self.put_email_verification(token, 404)
+
+    def test_post_respondent_with_no_body_returns_400(self):
+        self.post_to_respondents(None, 400)
+
+    @staticmethod
+    def test_verify_token_uses_case_insensitive_email_query():
+        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
+                patch('ras_party.support.session_decorator.current_app.db') as db:
+            # Given
+            token = generate_email_token('test@example.com', current_app.config)
+
+            # When
+            # pylint: disable=E1120
+            # session is injected by decorator
+            account_controller.verify_token(token)
+
+            # Then
+            query.assert_called_once_with('test@example.com', db.session())
+
+    @staticmethod
+    def test_change_respondent_password_uses_case_insensitive_email_query():
+        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
+                patch('ras_party.support.session_decorator.current_app.db') as db,\
+                patch('ras_party.controllers.account_controller.OauthClient') as client,\
+                patch('ras_party.controllers.account_controller.NotifyGateway'):
+            # Given
+            token = generate_email_token('test@example.com', current_app.config)
+            client().update_account().status_code = 201
+
+            # When
+            # pylint: disable=E1120
+            # session is injected by decorator
+            account_controller.change_respondent_password(token, {'new_password': 'abc'})
+
+            # Then
+            query.assert_called_once_with('test@example.com', db.session())
+
+    @staticmethod
+    def test_request_password_change_uses_case_insensitive_email_query():
+        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
+                patch('ras_party.support.session_decorator.current_app.db') as db,\
+                patch('ras_party.controllers.account_controller.NotifyGateway'),\
+                patch('ras_party.controllers.account_controller.PublicWebsite'):
+            # Given
+            payload = {'email_address': 'test@example.com'}
+
+            # When
+            # pylint: disable=E1120
+            # session is injected by decorator
+            account_controller.request_password_change(payload)
+
+            # Then
+            query.assert_called_once_with('test@example.com', db.session())
+
+    def test_post_respondent_uses_case_insensitive_email_query(self):
+        with patch('ras_party.controllers.queries.query_respondent_by_email') as query,\
+                patch('ras_party.support.session_decorator.current_app.db') as db,\
+                patch('ras_party.controllers.account_controller.NotifyGateway'),\
+                patch('ras_party.controllers.account_controller.Requests'):
+            # Given
+            payload = {
+                'emailAddress': 'test@example.com',
+                'firstName': 'Joe',
+                'lastName': 'bloggs',
+                'password': 'secure',
+                'telephone': '111',
+                'enrolmentCode': 'abc'
+            }
+            query('test@example.com', db.session()).return_value = None
+
+            # When
+            # pylint: disable=E1120
+            # session is injected by decorator
+            with self.assertRaises(RasError):
+                account_controller.post_respondent(payload)
+
+            # Then
+            query.assert_called_once_with('test@example.com', db.session())
+
+    @staticmethod
+    def test_put_email_verification_uses_case_insensitive_email_query():
+        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
+                patch('ras_party.support.session_decorator.current_app.db') as db:
+            # Given
+            token = generate_email_token('test@example.com', current_app.config)
+
+            # When
+            # pylint: disable=E1120
+            # session is injected by decorator
+            account_controller.put_email_verification(token)
+
+            # Then
+            query.assert_called_once_with('test@example.com', db.session())

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1,3 +1,5 @@
+#pylint: disable=no-value-for-parameter
+
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -24,6 +26,7 @@ class TestRespondents(PartyTestClient):
         self.mock_notify = MagicMock()
         account_controller.NotifyGateway = MagicMock(return_value=self.mock_notify)
         self.mock_respondent = MockRespondent().attributes().as_respondent()
+        self.respondent = None
 
     @transactional
     @with_db_session
@@ -43,10 +46,10 @@ class TestRespondents(PartyTestClient):
         account_controller.register_user(respondent, tran)
         return self.respondent
 
+    @staticmethod
     def generate_valid_token_from_email(self, email):
         frontstage_url = PublicWebsite(current_app.config).activate_account_url(email)
-        token = frontstage_url.split('/')[-1]
-        return token
+        return frontstage_url.split('/')[-1]
 
     def test_get_respondent_with_invalid_id(self):
         self.get_respondent_by_id('123', 400)


### PR DESCRIPTION
This will be the first steps for removing/refactoring the respondent endpoints in the party service.

Initial work includes: refactoring tests by isolating respondent-related activity and increasing test coverage overall where possible.