### PR TITLE
Log at error level for only major errors

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -124,13 +124,16 @@ def post_respondent(party, tran, session):
 
         _send_email_verification(respondent.party_uuid, party['emailAddress'])
     except (orm.exc.ObjectDeletedError, orm.exc.FlushError, orm.exc.StaleDataError, orm.exc.DetachedInstanceError):
+        logger.error('Error updating database for user', party_id=party['id'])
         msg = f"Error updating database for user id: {party['id']} "
         raise RasError(msg, status_code=500)
     except KeyError:
+        logger.error('Missing config keys during enrolment')
         msg = 'Missing config keys during enrolment'
         raise RasError(msg, status_code=500)
     except Exception as e:
-        msg = f'Error during enrolment process {e}'
+        logger.error(f'Error during enrolment process {e}')
+        msg = 'Error during enrolment process'
         raise RasError(msg, status_code=500)
 
     register_user(party, tran)
@@ -178,7 +181,9 @@ def change_respondent(payload, tran, session):
                                                         new_username=email_address,
                                                         account_verified='true')
         if rollback_response.status_code != 201:
-            raise RasError("Failed to rollback change to repsondent email. Please investigate.")
+            logger.error("Failed to rollback change to respondent email. Please investigate.",
+                         party_id=respondent.party_uuid)
+            raise RasError("Failed to rollback change to respondent email.")
 
     tran.compensate(compensate_oauth_change)
 

--- a/ras_party/error_handlers.py
+++ b/ras_party/error_handlers.py
@@ -29,7 +29,7 @@ def http_error(error):
 
 @blueprint.app_errorhandler(RasError)
 def ras_error(error):
-    logger.error(error.to_dict())
+    logger.info(error.to_dict())
     response = jsonify(error.to_dict())
     response.status_code = error.status_code
     return response

--- a/ras_party/support/verification.py
+++ b/ras_party/support/verification.py
@@ -16,7 +16,9 @@ def generate_email_token(email):
 
     # TODO: eventually implement a service startup check for all required config values
     if secret_key is None or email_token_salt is None:
-        raise RasError("SECRET_KEY or EMAIL_TOKEN_SALT are not configured.")
+        msg = "SECRET_KEY or EMAIL_TOKEN_SALT are not configured."
+        logger.error(msg)
+        raise RasError(msg)
 
     timed_serializer = URLSafeTimedSerializer(secret_key)
     return timed_serializer.dumps(email, salt=email_token_salt)


### PR DESCRIPTION
The general 'RasError' is used to raise every error and the error handler for this logs at error level which triggers lots of useless splunk alerts.
Note the RasError handler logs at info level and only logging at error level when needed before raising the RasError.
  