### PR TITLE
Disable IAC code when survey added

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -389,6 +389,12 @@ def add_new_survey_for_respondent(payload, tran, session):
 
     post_case_event(str(case_id), str(respondent_party_id), "RESPONDENT_ENROLED", "Respondent enroled")
 
+    # TODO This is not the correct way to do this and should be done in the case service.
+    # TODO This is very much temporary and should only be for release 15
+    iac_code = disable_iac_code(enrolment_code)
+    if iac_code.get('active', True):
+        raise RasError("Enrolment code has not been disabled", status=400)
+
     # This ensures the log message is only written once the DB transaction is committed
     tran.on_success(lambda: logger.info('Respondent has enroled to survey for business',
                                         survey_name=survey_name,
@@ -472,6 +478,15 @@ def request_iac(enrolment_code):
     logger.info('GET URL', url=iac_url)
     response = Requests.get(iac_url)
     logger.info('IAC service responded with', code=response.status_code)
+    response.raise_for_status()
+    return response.json()
+
+
+def disable_iac_code(iac_code):
+    logger.info('Disabling iac_code', iac_code=iac_code)
+    iac_svc = current_app.config['RAS_IAC_SERVICE']
+    iac_url = f'{iac_svc}/iacs/{iac_code}'
+    response = Requests.put(iac_url, json={"updatedBy": "SYSTEM"})
     response.raise_for_status()
     return response.json()
 

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -539,6 +539,10 @@ class TestRespondents(PartyTestClient):
             query.assert_called_once_with('test@example.test', db.session())
 
     def test_post_add_new_survey_no_respondent_business_association(self):
+
+        def mock_put_iac(*args, **kwargs):
+            return MockResponse('{"active": false}')
+        self.mock_requests.put = mock_put_iac
         self.populate_with_respondent(respondent=self.mock_respondent_with_id)
         self.populate_with_business()
         db_respondent = respondents()[0]
@@ -550,7 +554,43 @@ class TestRespondents(PartyTestClient):
         }
         self.add_survey(request_json, 200)
 
+    def test_post_add_new_survey_missing_status_from_iac(self):
+        def mock_put_iac(*args, **kwargs):
+            return MockResponse('{}')
+
+        self.mock_requests.put = mock_put_iac
+        self.populate_with_respondent(respondent=self.mock_respondent_with_id)
+        self.populate_with_business()
+        db_respondent = respondents()[0]
+        token = self.generate_valid_token_from_email(db_respondent.email_address)
+        self.put_email_verification(token, 200)
+        request_json = {
+            'party_id': self.mock_respondent_with_id['id'],
+            'enrolment_code': self.mock_respondent_with_id['enrolment_code']
+        }
+        self.add_survey(request_json, 400)
+
+    def test_post_add_new_survey_iac_not_disabled(self):
+        def mock_put_iac(*args, **kwargs):
+            return MockResponse('{"active": true}')
+
+        self.mock_requests.put = mock_put_iac
+        self.populate_with_respondent(respondent=self.mock_respondent_with_id)
+        self.populate_with_business()
+        db_respondent = respondents()[0]
+        token = self.generate_valid_token_from_email(db_respondent.email_address)
+        self.put_email_verification(token, 200)
+        request_json = {
+            'party_id': self.mock_respondent_with_id['id'],
+            'enrolment_code': self.mock_respondent_with_id['enrolment_code']
+        }
+        self.add_survey(request_json, 400)
+
     def test_post_add_new_survey_respondent_business_association(self):
+
+        def mock_put_iac(*args, **kwargs):
+            return MockResponse('{"active": false}')
+        self.mock_requests.put = mock_put_iac
         self.populate_with_respondent(respondent=self.mock_respondent_with_id)
         self.populate_with_business()
         self.associate_business_and_respondent(business_id='3b136c4b-7a14-4904-9e01-13364dd7b972',


### PR DESCRIPTION
The IAC should have its state change to active false when a new survey is added. This is not the long term intended solution and should be done in case. This is just for release 15 and should be reviewed with that in mind