### PR TITLE
Us057 change respondent name and number

### DIFF
--- a/API.md
+++ b/API.md
@@ -258,3 +258,16 @@ This page documents the Party service API endpoints. All endpoints return an `HT
 }
 ```
 &mdash; This endpoint will enrol a respondent in a survey and associate with business if not already associated.
+
+* `PUT /respondents/change_respondent_details/<respondent_id>`
+
+### Example JSON data for put
+```json
+{
+     " party_id": "438df969-7c9c-4cd4-a89b-ac88cf0bfdf3",
+     "firstName": "John",
+     "lastName": "Snow",
+     "telephone": "07837230942"
+}
+```
+&mdash; This endpoint will update the respondent details for an existing respondent.

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -81,10 +81,10 @@ def update_respondent_details(respondent_data, session):
 
     logger.debug('Updating respondent details', respondent_id=respondent_data['respondent_id'])
 
-    return session.query(Respondent).filter(Respondent.party_uuid == respondent_data['respondent_id']).update({
-                                            Respondent.first_name: respondent_data['firstName'],
-                                            Respondent.last_name: respondent_data['lastName'],
-                                            Respondent.telephone: respondent_data['telephone']})
+    session.query(Respondent).filter(Respondent.party_uuid == respondent_data['respondent_id']).update({
+                                     Respondent.first_name: respondent_data['firstName'],
+                                     Respondent.last_name: respondent_data['lastName'],
+                                     Respondent.telephone: respondent_data['telephone']})
 
 
 def search_businesses(search_query, session):

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -79,7 +79,7 @@ def query_change_respondent_details(respondent_data, session):
     :return: updated respondent details
     """
 
-    logger.debug('Changing respondent details', respondent_data=respondent_data)
+    logger.debug('Changing respondent details', respondent_id=respondent_data['respondent_id'])
 
     return session.query(Respondent).filter(Respondent.party_uuid == respondent_data['respondent_id']).update({
                                             Respondent.first_name: respondent_data['firstName'],

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -67,7 +67,7 @@ def query_business_respondent_by_respondent_id_and_business_id(business_id, resp
     return response
 
 
-def update_respondent_details(respondent_data, session):
+def update_respondent_details(respondent_data, respondent_id, session):
     """
     Query to return respondent, respondent_data consists of the following parameters
     :param respondent_data:
@@ -79,9 +79,9 @@ def update_respondent_details(respondent_data, session):
     :return: updated respondent details
     """
 
-    logger.debug('Updating respondent details', respondent_id=respondent_data['respondent_id'])
+    logger.debug('Updating respondent details', respondent_id=respondent_id)
 
-    session.query(Respondent).filter(Respondent.party_uuid == respondent_data['respondent_id']).update({
+    session.query(Respondent).filter(Respondent.party_uuid == respondent_id).update({
                                      Respondent.first_name: respondent_data['firstName'],
                                      Respondent.last_name: respondent_data['lastName'],
                                      Respondent.telephone: respondent_data['telephone']})

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -67,9 +67,10 @@ def query_business_respondent_by_respondent_id_and_business_id(business_id, resp
     return response
 
 
-def query_change_respondent_details(respondent_first_name, respondent_last_name, respondent_tel_number, session):
+def query_change_respondent_details(id, respondent_first_name, respondent_last_name, respondent_tel_number, session):
     """
     Query to return respondent
+    :param id:
     :param respondent_first_name:
     :param respondent_last_name:
     :param respondent_tel_number:
@@ -80,9 +81,10 @@ def query_change_respondent_details(respondent_first_name, respondent_last_name,
                  respondent_last_name=respondent_last_name,
                  respondent_tel_number=respondent_tel_number)
 
-    return session.query(Respondent).update(Respondent.first_name == respondent_first_name,
-                                            Respondent.last_name == respondent_last_name,
-                                            Respondent.telephone == respondent_tel_number)
+    return session.query(Respondent).filter(Respondent.id == id).update({
+                                            Respondent.first_name: respondent_first_name,
+                                            Respondent.last_name: respondent_last_name,
+                                            Respondent.telephone: respondent_tel_number})
 
 
 def search_businesses(search_query, session):

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -67,7 +67,7 @@ def query_business_respondent_by_respondent_id_and_business_id(business_id, resp
     return response
 
 
-def query_change_respondent_details(respondent_data, session):
+def update_respondent_details(respondent_data, session):
     """
     Query to return respondent, respondent_data consists of the following parameters
     :param respondent_data:
@@ -79,7 +79,7 @@ def query_change_respondent_details(respondent_data, session):
     :return: updated respondent details
     """
 
-    logger.debug('Changing respondent details', respondent_id=respondent_data['respondent_id'])
+    logger.debug('Updating respondent details', respondent_id=respondent_data['respondent_id'])
 
     return session.query(Respondent).filter(Respondent.party_uuid == respondent_data['respondent_id']).update({
                                             Respondent.first_name: respondent_data['firstName'],

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -67,24 +67,22 @@ def query_business_respondent_by_respondent_id_and_business_id(business_id, resp
     return response
 
 
-def query_change_respondent_details(id, respondent_first_name, respondent_last_name, respondent_tel_number, session):
+def query_change_respondent_details(respondent_data, session):
     """
-    Query to return respondent
-    :param id:
-    :param respondent_first_name:
-    :param respondent_last_name:
-    :param respondent_tel_number:
-    :param session:
-    :return: respondent or none
+    Query to return respondent, respondent_data consists of the following parameters
+    :param respondent_id:
+    :param first_name:
+    :param last_name:
+    :param telephone:
+    :return: updated respondent details
     """
-    logger.debug('Changing respondent details', respondent_first_name=respondent_first_name,
-                 respondent_last_name=respondent_last_name,
-                 respondent_tel_number=respondent_tel_number)
 
-    return session.query(Respondent).filter(Respondent.id == id).update({
-                                            Respondent.first_name: respondent_first_name,
-                                            Respondent.last_name: respondent_last_name,
-                                            Respondent.telephone: respondent_tel_number})
+    logger.debug('Changing respondent details', respondent_data=respondent_data)
+
+    return session.query(Respondent).filter(Respondent.id == respondent_data['respondent_id']).update({
+                                            Respondent.first_name: respondent_data['firstName'],
+                                            Respondent.last_name: respondent_data['lastName'],
+                                            Respondent.telephone: respondent_data['telephone']})
 
 
 def search_businesses(search_query, session):

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -67,6 +67,24 @@ def query_business_respondent_by_respondent_id_and_business_id(business_id, resp
     return response
 
 
+def query_change_respondent_details(respondent_first_name, respondent_last_name, respondent_tel_number, session):
+    """
+    Query to return respondent
+    :param respondent_first_name:
+    :param respondent_last_name:
+    :param respondent_tel_number:
+    :param session:
+    :return: respondent or none
+    """
+    logger.debug('Changing respondent details', respondent_first_name=respondent_first_name,
+                 respondent_last_name=respondent_last_name,
+                 respondent_tel_number=respondent_tel_number)
+
+    return session.query(Respondent).update(Respondent.first_name == respondent_first_name,
+                                            Respondent.last_name == respondent_last_name,
+                                            Respondent.telephone == respondent_tel_number)
+
+
 def search_businesses(search_query, session):
     """
     Query to return list of businesses based on search query

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -70,16 +70,18 @@ def query_business_respondent_by_respondent_id_and_business_id(business_id, resp
 def query_change_respondent_details(respondent_data, session):
     """
     Query to return respondent, respondent_data consists of the following parameters
-    :param respondent_id:
-    :param first_name:
-    :param last_name:
-    :param telephone:
+    :param respondent_data:
+        respondent_id: id of the respondent
+        first_name:
+        last_name:
+        telephone:
+    :param session
     :return: updated respondent details
     """
 
     logger.debug('Changing respondent details', respondent_data=respondent_data)
 
-    return session.query(Respondent).filter(Respondent.id == respondent_data['respondent_id']).update({
+    return session.query(Respondent).filter(Respondent.party_uuid == respondent_data['respondent_id']).update({
                                             Respondent.first_name: respondent_data['firstName'],
                                             Respondent.last_name: respondent_data['lastName'],
                                             Respondent.telephone: respondent_data['telephone']})

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -76,7 +76,6 @@ def update_respondent_details(respondent_data, respondent_id, session):
         last_name:
         telephone:
     :param session
-    :return: updated respondent details
     """
 
     logger.debug('Updating respondent details', respondent_id=respondent_id)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -50,4 +50,8 @@ def change_respondent_details(respondent_data, session):
     :param session:
     :return:
     """
+    v = Validator(IsUuid('respondent_id'))
+    if not v.validate({'respondent_id': respondent_data['respondent_id']}):
+        raise RasError(v.errors, status=404)
+
     query_change_respondent_details(respondent_data, session)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -2,6 +2,7 @@ from ras_party.controllers.queries import query_respondent_by_party_uuid, query_
     query_change_respondent_details
 from ras_party.controllers.validate import Validator, IsUuid, Exists
 from ras_party.exceptions import RasError
+from ras_party.models.models import Respondent
 from ras_party.support.session_decorator import with_db_session
 
 
@@ -44,28 +45,16 @@ def get_respondent_by_email(email, session):
 
 
 @with_db_session
-def change_respondent_details(id, respondent_first_name, respondent_last_name, respondent_tel_number, session):
+def change_respondent_details(respondent_data, session):
     """
-    :param id: ID of Respondent to return
+    :param respondent_id: ID of Respondent to return
+    :param respondent_data:
     :param respondent_first_name:
     :param respondent_last_name:
     :param respondent_tel_number:
     :param session:
     :return:
     """
-    v = Validator(Exists('respondent_first_name', 'respondent_last_name', 'respondent_tel_number'))
-
-    if not v.validate(respondent_first_name):
-        raise RasError(v.errors, status=400)
-    if not v.validate(respondent_last_name):
-        raise RasError(v.errors, status=400)
-    if not v.validate(respondent_tel_number):
-        raise RasError(v.errors, status=400)
-
-    respondent = query_change_respondent_details(id,
-                                                 respondent_first_name,
-                                                 respondent_last_name,
-                                                 respondent_tel_number,
-                                                 session)
+    respondent = query_change_respondent_details(respondent_data, session)
 
     return respondent.to_respondent_dict()

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -1,5 +1,5 @@
-from ras_party.controllers.queries import query_respondent_by_party_uuid, query_respondent_by_email
-from ras_party.controllers.validate import Validator, IsUuid
+from ras_party.controllers.queries import query_respondent_by_party_uuid, query_respondent_by_email, query_change_respondent_details
+from ras_party.controllers.validate import Validator, IsUuid, Exists
 from ras_party.exceptions import RasError
 from ras_party.support.session_decorator import with_db_session
 
@@ -40,3 +40,28 @@ def get_respondent_by_email(email, session):
         raise RasError("Respondent does not exist.", status=404)
 
     return respondent.to_respondent_dict()
+
+
+@with_db_session
+def change_respondent_details(respondent_first_name, respondent_last_name, respondent_tel_number, session):
+    """
+    :param respondent_first_name:
+    :param respondent_last_name:
+    :param respondent_tel_number:
+    :param session:
+    :return:
+    """
+    v = Validator(Exists('respondent_first_name', 'respondent_last_name', 'respondent_tel_number'))
+    if not v.validate(respondent_first_name):
+        raise RasError(v.errors, status=400)
+    if not v.validate(respondent_last_name):
+        raise RasError(v.errors, status=400)
+    if not v.validate(respondent_tel_number):
+        raise RasError(v.errors, status=400)
+
+    respondent = query_change_respondent_details(respondent_first_name,
+                                                 respondent_last_name,
+                                                 respondent_tel_number,
+                                                 session)
+    if not respondent:
+        raise RasError("Respondent does not exist.", status=404)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -54,10 +54,7 @@ def change_respondent_details(id, respondent_first_name, respondent_last_name, r
     :return:
     """
     v = Validator(Exists('respondent_first_name', 'respondent_last_name', 'respondent_tel_number'))
-    v_id = Validator(IsUuid('id'))
 
-    if not v_id.validate({'id': id}):
-        raise RasError(v.errors, status=400)
     if not v.validate(respondent_first_name):
         raise RasError(v.errors, status=400)
     if not v.validate(respondent_last_name):
@@ -70,10 +67,5 @@ def change_respondent_details(id, respondent_first_name, respondent_last_name, r
                                                  respondent_last_name,
                                                  respondent_tel_number,
                                                  session)
-    if respondent:
-        session.merge(respondent)
-
-    else:
-        raise RasError("Respondent does not exist.", status=404)
 
     return respondent.to_respondent_dict()

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -44,14 +44,11 @@ def get_respondent_by_email(email, session):
 
 
 @with_db_session
-def change_respondent_details(respondent_data, session):
+def change_respondent_details(respondent_data, respondent_id, session):
     """
     :param respondent_data:
     :param session:
     :return:
     """
-    v = Validator(IsUuid('respondent_id'))
-    if not v.validate({'respondent_id': respondent_data['respondent_id']}):
-        raise RasError(v.errors, status=400)
 
-    update_respondent_details(respondent_data, session)
+    update_respondent_details(respondent_data, respondent_id, session)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -47,6 +47,7 @@ def get_respondent_by_email(email, session):
 def change_respondent_details(respondent_data, respondent_id, session):
     """
     :param respondent_data:
+    :param respondent_id
     :param session:
     :return:
     """
@@ -56,4 +57,3 @@ def change_respondent_details(respondent_data, respondent_id, session):
         raise RasError("Respondent id does not exist.", id=respondent_id, status=404)
 
     update_respondent_details(respondent_data, respondent_id, session)
-

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -51,4 +51,9 @@ def change_respondent_details(respondent_data, respondent_id, session):
     :return:
     """
 
+    respondent = query_respondent_by_party_uuid(respondent_id, session)
+    if not respondent:
+        raise RasError("Respondent id does not exist.", id=respondent_id, status=404)
+
     update_respondent_details(respondent_data, respondent_id, session)
+

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -1,5 +1,5 @@
 from ras_party.controllers.queries import query_respondent_by_party_uuid, query_respondent_by_email,\
-    query_change_respondent_details
+    update_respondent_details
 from ras_party.controllers.validate import Validator, IsUuid
 from ras_party.exceptions import RasError
 from ras_party.support.session_decorator import with_db_session
@@ -52,6 +52,6 @@ def change_respondent_details(respondent_data, session):
     """
     v = Validator(IsUuid('respondent_id'))
     if not v.validate({'respondent_id': respondent_data['respondent_id']}):
-        raise RasError(v.errors, status=404)
+        raise RasError(v.errors, status=400)
 
-    query_change_respondent_details(respondent_data, session)
+    update_respondent_details(respondent_data, session)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -1,8 +1,7 @@
 from ras_party.controllers.queries import query_respondent_by_party_uuid, query_respondent_by_email,\
     query_change_respondent_details
-from ras_party.controllers.validate import Validator, IsUuid, Exists
+from ras_party.controllers.validate import Validator, IsUuid
 from ras_party.exceptions import RasError
-from ras_party.models.models import Respondent
 from ras_party.support.session_decorator import with_db_session
 
 
@@ -47,14 +46,8 @@ def get_respondent_by_email(email, session):
 @with_db_session
 def change_respondent_details(respondent_data, session):
     """
-    :param respondent_id: ID of Respondent to return
     :param respondent_data:
-    :param respondent_first_name:
-    :param respondent_last_name:
-    :param respondent_tel_number:
     :param session:
     :return:
     """
-    respondent = query_change_respondent_details(respondent_data, session)
-
-    return respondent.to_respondent_dict()
+    query_change_respondent_details(respondent_data, session)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -21,7 +21,7 @@ def get_respondent_by_id(id, session):
 
     respondent = query_respondent_by_party_uuid(id, session)
     if not respondent:
-        raise RasError("Respondent with party id does not exist.", id=id, status=404)
+        raise RasError("Respondent with party id does not exist.", respondent_id=id, status=404)
 
     return respondent.to_respondent_dict()
 
@@ -54,6 +54,6 @@ def change_respondent_details(respondent_data, respondent_id, session):
 
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise RasError("Respondent id does not exist.", id=respondent_id, status=404)
+        raise RasError("Respondent id does not exist.", respondent_id=respondent_id, status=404)
 
     update_respondent_details(respondent_data, respondent_id, session)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -40,8 +40,8 @@ def get_respondent_by_email(email):
     return make_response(jsonify(response), 200)
 
 
-@respondent_view.route('/respondents/change_respondent_details', methods=['PUT'])
-def change_respondent_details():
+@respondent_view.route('/respondents/change_respondent_details/<respondent_id>', methods=['PUT'])
+def change_respondent_details(respondent_id):
     payload = request.get_json()
-    ras_party.controllers.respondent_controller.change_respondent_details(payload)
+    ras_party.controllers.respondent_controller.change_respondent_details(payload, respondent_id)
     return make_response('Successfully updated respondent details', 200)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -38,3 +38,11 @@ def get_respondent_by_id(id):
 def get_respondent_by_email(email):
     response = ras_party.controllers.respondent_controller.get_respondent_by_email(email)
     return make_response(jsonify(response), 200)
+
+
+@respondent_view.route('/respondents/change_respondent_details', methods=['PUT'])
+def change_respondent_details(first_name, last_name, telephone):
+    response = ras_party.controllers.respondent_controller.query_change_respondent_details(first_name,
+                                                                                           last_name,
+                                                                                           telephone)
+    return make_response(jsonify(response), 200)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, make_response, jsonify
+from flask import Blueprint, current_app, make_response, jsonify, request
 from flask_httpauth import HTTPBasicAuth
 
 import ras_party.controllers.account_controller
@@ -41,9 +41,7 @@ def get_respondent_by_email(email):
 
 
 @respondent_view.route('/respondents/change_respondent_details', methods=['PUT'])
-def change_respondent_details(id, first_name, last_name, telephone):
-    response = ras_party.controllers.respondent_controller.query_change_respondent_details(id,
-                                                                                           first_name,
-                                                                                           last_name,
-                                                                                           telephone)
+def change_respondent_details():
+    payload = request.get_json()
+    response = ras_party.controllers.respondent_controller.change_respondent_details(payload)
     return make_response(jsonify(response), 200)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -43,5 +43,5 @@ def get_respondent_by_email(email):
 @respondent_view.route('/respondents/change_respondent_details', methods=['PUT'])
 def change_respondent_details():
     payload = request.get_json()
-    response = ras_party.controllers.respondent_controller.change_respondent_details(payload)
-    return make_response(jsonify(response), 200)
+    ras_party.controllers.respondent_controller.change_respondent_details(payload)
+    return make_response('Successfully updated respondent details', 200)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -41,8 +41,9 @@ def get_respondent_by_email(email):
 
 
 @respondent_view.route('/respondents/change_respondent_details', methods=['PUT'])
-def change_respondent_details(first_name, last_name, telephone):
-    response = ras_party.controllers.respondent_controller.query_change_respondent_details(first_name,
+def change_respondent_details(id, first_name, last_name, telephone):
+    response = ras_party.controllers.respondent_controller.query_change_respondent_details(id,
+                                                                                           first_name,
                                                                                            last_name,
                                                                                            telephone)
     return make_response(jsonify(response), 200)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -40,7 +40,7 @@ def get_respondent_by_email(email):
     return make_response(jsonify(response), 200)
 
 
-@respondent_view.route('/respondents/change_respondent_details/<respondent_id>', methods=['PUT'])
+@respondent_view.route('/respondents/id/<respondent_id>', methods=['PUT'])
 def change_respondent_details(respondent_id):
     payload = request.get_json()
     ras_party.controllers.respondent_controller.change_respondent_details(payload, respondent_id)

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -187,7 +187,7 @@ class PartyTestClient(TestCase):
         return json.loads(response.get_data(as_text=True))
 
     def change_respondent_details(self, respondent_id, payload, expected_status=200):
-        response = self.client.put(f'/party-api/v1/respondents/change_respondent_details/{respondent_id}',
+        response = self.client.put(f'/party-api/v1/respondents/id/{respondent_id}',
                                    headers=self.auth_headers,
                                    data=json.dumps(payload),
                                    content_type='application/vnd.ons.business+json')

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -185,3 +185,10 @@ class PartyTestClient(TestCase):
                                    headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
+
+    def change_respondent_details(self, id, first_name, last_name, telephone, expected_status=200):
+        response = self.client.put(f'/party-api/v1/respondents/change_respondent_details',
+                                   headers=self.auth_headers,
+                                   data=json.dumps(payload))
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -186,8 +186,8 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def change_respondent_details(self, payload, expected_status=200):
-        response = self.client.put(f'/party-api/v1/respondents/change_respondent_details',
+    def change_respondent_details(self, respondent_id, payload, expected_status=200):
+        response = self.client.put(f'/party-api/v1/respondents/change_respondent_details/{respondent_id}',
                                    headers=self.auth_headers,
                                    data=json.dumps(payload),
                                    content_type='application/vnd.ons.business+json')

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -189,6 +189,7 @@ class PartyTestClient(TestCase):
     def change_respondent_details(self, payload, expected_status=200):
         response = self.client.put(f'/party-api/v1/respondents/change_respondent_details',
                                    headers=self.auth_headers,
-                                   data=json.dumps(payload))
-        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
-        return json.loads(response.get_data(as_text=True))
+                                   data=json.dumps(payload),
+                                   content_type='application/vnd.ons.business+json')
+        self.assertStatus(response, expected_status)
+        return response.get_data(as_text=True)

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -186,7 +186,7 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def change_respondent_details(self, id, first_name, last_name, telephone, expected_status=200):
+    def change_respondent_details(self, payload, expected_status=200):
         response = self.client.put(f'/party-api/v1/respondents/change_respondent_details',
                                    headers=self.auth_headers,
                                    data=json.dumps(payload))

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -102,17 +102,24 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
 
     def test_change_respondent_details_success(self):
-        respondent = self.populate_with_respondent()
-        payload = {'firstName': respondent.first_name,
-                   'lastName': respondent.last_name,
-                   'telephone': respondent.telephone}
-        self.change_respondent_details(payload, expected_status=200)
+        self.populate_with_respondent()
+        payload = {
+            "respondent_id": "438df969-7c9c-4cd4-a89b-ac88cf0bfdf3",
+            "firstName": "John",
+            "lastName": "Snow",
+            "telephone": "07837230942"
+        }
+        self.change_respondent_details(payload, 200)
 
-    def test_change_respondent_details_failed(self):
-        payload = {'firstName': '',
-                   'lastName': '',
-                   'telephone': ''}
-        self.change_respondent_details(payload, expected_status=400)
+    def test_change_respondent_details_respondent_does_not_exist(self):
+        self.populate_with_respondent()
+        payload = {
+            "respondent_id": "",
+            "firstName": "John",
+            "lastName": "Bloggs",
+            "telephone": "07837230942"
+        }
+        self.change_respondent_details(payload, 404)
 
     def test_resend_verification_email(self):
         # Given there is a respondent

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -101,6 +101,13 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['sampleUnitType'], self.mock_respondent['sampleUnitType'])
         self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
 
+    def test_change_respondent_details(self):
+        respondent = self.populate_with_respondent()
+        payload = {'first_name': respondent.first_name,
+                   'last_name': respondent.last_name,
+                   'telephone': respondent.telephone}
+        self.change_respondent_details(payload)
+
     def test_resend_verification_email(self):
         # Given there is a respondent
         respondent = self.populate_with_respondent()

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -101,12 +101,19 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['sampleUnitType'], self.mock_respondent['sampleUnitType'])
         self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
 
-    def test_change_respondent_details(self):
+    def test_change_respondent_details_success(self):
         respondent = self.populate_with_respondent()
-        payload = {'first_name': respondent.first_name,
-                   'last_name': respondent.last_name,
+        payload = {'firstName': respondent.first_name,
+                   'lastName': respondent.last_name,
                    'telephone': respondent.telephone}
-        self.change_respondent_details(payload)
+        self.change_respondent_details(payload, expected_status=200)
+
+    def test_change_respondent_details_failed(self):
+        respondent = self.populate_with_respondent()
+        payload = {'firstName': '',
+                   'lastName': '',
+                   'telephone': ''}
+        self.change_respondent_details(payload, expected_status=400)
 
     def test_resend_verification_email(self):
         # Given there is a respondent

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -98,10 +98,10 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['emailAddress'], self.mock_respondent['emailAddress'])
         self.assertEqual(response['firstName'], self.mock_respondent['firstName'])
         self.assertEqual(response['lastName'], self.mock_respondent['lastName'])
-        self.assertEqual(response['sampleUnitType'], self.mock_respondent['sampleUnitType'])
+        self.assertEqual(response['sampleUnitType'], self.mock_respondent ['sampleUnitType'])
         self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
 
-    def test_change_respondent_details_success(self):
+    def test_update_respondent_details_success(self):
         self.populate_with_respondent()
         payload = {
             "respondent_id": "438df969-7c9c-4cd4-a89b-ac88cf0bfdf3",
@@ -111,7 +111,7 @@ class TestRespondents(PartyTestClient):
         }
         self.change_respondent_details(payload, 200)
 
-    def test_change_respondent_details_respondent_does_not_exist(self):
+    def test_update_respondent_details_respondent_does_not_exist_error(self):
         self.populate_with_respondent()
         payload = {
             "respondent_id": "",
@@ -119,7 +119,7 @@ class TestRespondents(PartyTestClient):
             "lastName": "Bloggs",
             "telephone": "07837230942"
         }
-        self.change_respondent_details(payload, 404)
+        self.change_respondent_details(payload, 400)
 
     def test_resend_verification_email(self):
         # Given there is a respondent

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -102,24 +102,24 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
 
     def test_update_respondent_details_success(self):
-        self.populate_with_respondent()
+        self.populate_with_respondent(respondent=self.mock_respondent_with_id)
+        respondent_id = self.mock_respondent_with_id['id']
         payload = {
-            "respondent_id": "438df969-7c9c-4cd4-a89b-ac88cf0bfdf3",
             "firstName": "John",
             "lastName": "Snow",
             "telephone": "07837230942"
-        }
-        self.change_respondent_details(payload, 200)
+            }
+        self.change_respondent_details(respondent_id, payload, 200)
 
     def test_update_respondent_details_respondent_does_not_exist_error(self):
         self.populate_with_respondent()
+        respondent_id = ''
         payload = {
-            "respondent_id": "",
             "firstName": "John",
             "lastName": "Bloggs",
             "telephone": "07837230942"
-        }
-        self.change_respondent_details(payload, 400)
+            }
+        self.change_respondent_details(respondent_id, payload, 404)
 
     def test_resend_verification_email(self):
         # Given there is a respondent

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -109,7 +109,6 @@ class TestRespondents(PartyTestClient):
         self.change_respondent_details(payload, expected_status=200)
 
     def test_change_respondent_details_failed(self):
-        respondent = self.populate_with_respondent()
         payload = {'firstName': '',
                    'lastName': '',
                    'telephone': ''}

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -98,7 +98,7 @@ class TestRespondents(PartyTestClient):
         self.assertEqual(response['emailAddress'], self.mock_respondent['emailAddress'])
         self.assertEqual(response['firstName'], self.mock_respondent['firstName'])
         self.assertEqual(response['lastName'], self.mock_respondent['lastName'])
-        self.assertEqual(response['sampleUnitType'], self.mock_respondent ['sampleUnitType'])
+        self.assertEqual(response['sampleUnitType'], self.mock_respondent['sampleUnitType'])
         self.assertEqual(response['telephone'], self.mock_respondent['telephone'])
 
     def test_update_respondent_details_success(self):


### PR DESCRIPTION
This PR is linked to the other Us057 requests in backstage (https://github.com/ONSdigital/ras-backstage/pull/73) and response operations (awaiting PR for r-ops).

This adds in the functionality to update a respondents `first name`, `last_name`, `telephone`

