### PR TITLE
Make email verification expiry configurable and set default to 85 hours

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,6 +25,7 @@ class Config(object):
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     SECRET_KEY = os.getenv('SECRET_KEY', 'aardvark')
     EMAIL_TOKEN_SALT = os.getenv('EMAIL_TOKEN_SALT', 'aardvark')
+    EMAIL_TOKEN_EXPIRY = int(os.getenv('EMAIL_TOKEN_EXPIRY', 288000))
     PARTY_SCHEMA = os.getenv('PARTY_SCHEMA', 'ras_party/schemas/party_schema.json')
 
     if cf.detected:

--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ class Config(object):
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     SECRET_KEY = os.getenv('SECRET_KEY', 'aardvark')
     EMAIL_TOKEN_SALT = os.getenv('EMAIL_TOKEN_SALT', 'aardvark')
-    EMAIL_TOKEN_EXPIRY = int(os.getenv('EMAIL_TOKEN_EXPIRY', 288000))
+    EMAIL_TOKEN_EXPIRY = int(os.getenv('EMAIL_TOKEN_EXPIRY', 306000))
     PARTY_SCHEMA = os.getenv('PARTY_SCHEMA', 'ras_party/schemas/party_schema.json')
 
     if cf.detected:

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -197,7 +197,7 @@ def change_respondent(payload, tran, session):
 @with_db_session
 def verify_token(token, session):
     try:
-        duration = int(current_app.config.get("EMAIL_TOKEN_EXPIRY", '86400'))
+        duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
         email_address = decode_email_token(token, duration)
     except SignatureExpired:
         raise RasError('Expired email verification token', status=409, token=token)
@@ -219,7 +219,7 @@ def change_respondent_password(token, payload, tran, session):
         raise RasError(v.errors, 400)
 
     try:
-        duration = int(current_app.config.get("EMAIL_TOKEN_EXPIRY", '86400'))
+        duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
         email_address = decode_email_token(token, duration)
     except SignatureExpired:
         raise RasError('Expired email verification token', status=409, token=token)
@@ -294,7 +294,7 @@ def request_password_change(payload, session):
 @with_db_session
 def put_email_verification(token, session):
     try:
-        duration = int(current_app.config.get("EMAIL_TOKEN_EXPIRY", '86400'))
+        duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
         email_address = decode_email_token(token, duration)
     except SignatureExpired:
         raise RasError('Expired email verification token', status=409, token=token)


### PR DESCRIPTION
Make email verification expiry configurable from the `config.py` file and set new default of 80 hours