### PR TITLE
Us020 deactivate account v2

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -550,5 +550,3 @@ def set_bi_cases_for_party_to_inactionable(party_id):
 
     for case in cases:
         post_case_event(case['id'], party_id, category='DEACTIVATED')
-
-

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -12,6 +12,7 @@ from ras_party.controllers.queries import query_respondent_by_email, query_respo
 from ras_party.controllers.queries import query_respondent_by_party_uuid, query_business_by_party_uuid
 from ras_party.controllers.queries import query_business_respondent_by_respondent_id_and_business_id
 from ras_party.controllers.queries import query_enrolment_by_survey_business_respondent
+from ras_party.controllers.queries import update_respondent_enrolments_to_disabled
 from ras_party.controllers.validate import Exists, IsUuid, Validator
 from ras_party.exceptions import RasError, RasNotifyError
 from ras_party.models.models import BusinessRespondent, Enrolment, EnrolmentStatus
@@ -306,6 +307,7 @@ def change_respondent_account_status(payload, party_id, session):
         raise RasError("Unable to find respondent account", status=404)
 
     if status.lower() == 'suspended':
+        update_respondent_enrolments_to_disabled(respondent.id, session)
         set_bi_cases_for_party_to_inactionable(party_id)
     respondent.status = status
 

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -609,9 +609,8 @@ def set_bi_cases_for_party_to_inactionable(party_id):
     logger.debug("Set respondent BI cases to inactionable", party_id=party_id)
 
     cases = request_cases_for_respondent(party_id, state='ACTIONABLE')
-    if cases:
-        for case in cases:
-            post_case_event(case['id'], party_id, category='DEACTIVATED')
+    for case in cases:
+        post_case_event(case['id'], party_id, category='DEACTIVATED')
 
 
 def request_casegroups_for_business(business_id):
@@ -620,7 +619,7 @@ def request_casegroups_for_business(business_id):
     response = Requests.get(url)
     response.raise_for_status()
     logger.debug('Successfully retrieved casegroups for business', business_id=business_id)
-    return response.json()
+    return response.json() if response.json() else []
 
 
 def request_collection_exercises_for_survey(survey_id):

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -577,12 +577,12 @@ def request_cases_for_respondent(respondent_id, state=None):
 
 
 def set_bi_cases_for_party_to_inactionable(party_id):
-    logger.debug("Set respondent BI cases to inactionable", party_id)
+    logger.debug("Set respondent BI cases to inactionable", party_id=party_id)
 
     cases = request_cases_for_respondent(party_id, state='ACTIONABLE')
-
-    for case in cases:
-        post_case_event(case['id'], party_id, category='DEACTIVATED')
+    if cases:
+        for case in cases:
+            post_case_event(case['id'], party_id, category='DEACTIVATED')
 
 
 def request_casegroups_for_business(business_id):

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -154,3 +154,17 @@ def query_enrolment_by_survey_business_respondent(respondent_id, business_id, su
                                                     Enrolment.business_id == business_id,
                                                     Enrolment.survey_id == survey_id)).first()
     return response
+
+
+def update_respondent_enrolments_to_disabled(respondent_id, session):
+    """
+    Update respondent enrolments to disabled state when account suspended
+    :param respondent_id
+    :param session 
+    :return 
+    """
+
+    logger.debug('Updating respondent enrolments')
+
+    session.query(Enrolment).filter(Enrolment.respondent_id == respondent_id).update({
+                                            Enrolment.status: 'DISABLED'})

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -38,6 +38,8 @@ class MockRequests:
                         MockResponse(get_cases_by_party.response),
                     'http://mockhost:1111/casegroups/partyid/3b136c4b-7a14-4904-9e01-13364dd7b972':
                         MockResponse(get_casegroups_by_party.response),
+                    'http://mockhost:1111/cases/partyid/438df969-7c9c-4cd4-a89b-ac88cf0bfdf3?state=ACTIONABLE':
+                        MockResponse(get_casegroups_by_party.response),
                     'http://mockhost:2222/collectionexercises/dab9db7f-3aa0-4866-be20-54d72ee185fb':
                         MockResponse(get_ce_by_id.response),
                     'http://mockhost:2222/collectionexercises/survey/02b9c366-7397-42f7-942a-76dc5876d86d':

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -775,6 +775,9 @@ class TestRespondents(PartyTestClient):
         self.put_enrolment_status(request_json, 500)
 
     def test_put_change_respondent_account_status_suspend(self):
+        def mock_put_iac(*args, **kwargs):
+            return MockResponse('{"active": false}')
+        self.mock_requests.put = mock_put_iac
         self.populate_with_respondent(respondent=self.mock_respondent_with_id)
         db_respondent = respondents()[0]
         token = self.generate_valid_token_from_email(db_respondent.email_address)


### PR DESCRIPTION
Add functionality to suspending account to set all respondents actionable BI cases to in-actionable so they no longer receive communications.

Linked PRs:
https://github.com/ONSdigital/rm-case-service/pull/30
https://github.com/ONSdigital/response-operations-ui/pull/125 