### PR TITLE
Change search for respondent by email to return created users

### DIFF
--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -63,18 +63,6 @@ def query_respondent_by_pending_email(email, session):
     return session.query(Respondent).filter(func.lower(Respondent.pending_email_address) == email.lower()).first()
 
 
-def query_respondent_by_email_filter_out_created(email, session):
-    """
-    Query to return respondent based on email
-    :param email: the party uuid
-    :return: respondent or none
-    """
-    logger.debug('Querying respondents by email')
-
-    return session.query(Respondent).filter(and_(func.lower(Respondent.email_address) == email.lower(),
-                                                 Respondent.status != 'CREATED')).first()
-
-
 def query_business_respondent_by_respondent_id_and_business_id(business_id, respondent_id, session):
     """
     Query to return respondent business associations based on respondent id

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -1,5 +1,5 @@
 from ras_party.controllers.queries import query_respondent_by_party_uuid, \
-    query_respondent_by_email_filter_out_created, update_respondent_details
+    query_respondent_by_email, update_respondent_details
 from ras_party.controllers.validate import Validator, IsUuid
 from ras_party.exceptions import RasError
 from ras_party.support.session_decorator import with_db_session
@@ -37,7 +37,7 @@ def get_respondent_by_email(email, session):
     :param email: Email of respondent to lookup
     :rtype: Respondent
     """
-    respondent = query_respondent_by_email_filter_out_created(email, session)
+    respondent = query_respondent_by_email(email, session)
     if not respondent:
         raise RasError("Respondent does not exist.", status=404)
 


### PR DESCRIPTION
For US115 this allows respondent to be searched for using email to return created respondents.