### PR TITLE
Remove isUuid from validator class and code.

### DIFF
--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -1,7 +1,9 @@
+import uuid
+
 from flask import current_app
 
 from ras_party.controllers.queries import query_business_by_ref, query_business_by_party_uuid, search_businesses
-from ras_party.controllers.validate import Validator, IsUuid, Exists
+from ras_party.controllers.validate import Validator, Exists
 from ras_party.exceptions import RasError
 from ras_party.models.models import Business, BusinessAttributes
 from ras_party.support.session_decorator import with_db_session
@@ -44,9 +46,10 @@ def get_business_by_id(party_uuid, session, verbose=False, collection_exercise_i
 
     :rtype: Business
     """
-    v = Validator(IsUuid('id'))
-    if not v.validate({'id': party_uuid}):
-        raise RasError(v.errors, status=400)
+    try:
+        uuid.UUID(party_uuid)
+    except ValueError:
+        raise RasError(f"'{party_uuid}' is not a valid UUID format for property 'id'", status=400)
 
     business = query_business_by_party_uuid(party_uuid, session)
     if not business:

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -39,7 +39,7 @@ def get_businesses_by_ids(party_uuids, session):
         try:
             uuid.UUID(party_uuid)
         except ValueError:
-            raise RasError(f"'{party_uuid}' is not a valid UUID format for property 'id'", status=400)
+            raise RasError(f"'{party_uuid}' is not a valid UUID format for property 'id'.", status=400)
 
     businesses = query_businesses_by_party_uuids(party_uuids, session)
     return [business.to_business_summary_dict() for business in businesses]

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -22,7 +22,7 @@ def get_respondent_by_ids(ids, session):
         try:
             uuid.UUID(party_id)
         except ValueError:
-            raise RasError(f"'{party_id}' is not a valid UUID format for property 'id'", status=400)
+            raise RasError(f"'{party_id}' is not a valid UUID format for property 'id'.", status=400)
 
     respondents = query_respondent_by_party_uuids(ids, session)
     return [respondent.to_respondent_dict() for respondent in respondents]
@@ -41,7 +41,7 @@ def get_respondent_by_id(id, session):
     try:
         uuid.UUID(id)
     except ValueError:
-        raise RasError(f"'{id}' is not a valid UUID format for property 'id'", status=400)
+        raise RasError(f"'{id}' is not a valid UUID format for property 'id'.", status=400)
 
     respondent = query_respondent_by_party_uuid(id, session)
     if not respondent:

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -1,6 +1,7 @@
+import uuid
+
 from ras_party.controllers.queries import query_respondent_by_party_uuid, \
     query_respondent_by_email, update_respondent_details
-from ras_party.controllers.validate import Validator, IsUuid
 from ras_party.exceptions import RasError
 from ras_party.support.session_decorator import with_db_session
 from ras_party.controllers.account_controller import change_respondent
@@ -16,9 +17,10 @@ def get_respondent_by_id(id, session):
 
     :rtype: Respondent
     """
-    v = Validator(IsUuid('id'))
-    if not v.validate({'id': id}):
-        raise RasError(v.errors, status=400)
+    try:
+        uuid.UUID(id)
+    except ValueError:
+        raise RasError(f"'{id}' is not a valid UUID format for property 'id'", status=400)
 
     respondent = query_respondent_by_party_uuid(id, session)
     if not respondent:

--- a/ras_party/controllers/validate.py
+++ b/ras_party/controllers/validate.py
@@ -1,5 +1,4 @@
 import itertools
-import uuid
 
 from ras_party.support.util import flatten_keys
 
@@ -53,25 +52,6 @@ class MutuallyExclusive(ValidatorBase):
         self._intersection = self._keys.intersection(keys)
         self._errors = [self.ERROR_MESSAGE.format(list(self._intersection))]
         return len(self._intersection) <= 1
-
-
-class IsUuid(ValidatorBase):
-
-    ERROR_MESSAGE = "'{}' is not a valid UUID format for property '{}'."
-
-    def __init__(self, key):
-        super().__init__()
-        self._key = key
-        self._value = None
-
-    def __call__(self, data):
-        self._value = data[self._key]
-        try:
-            uuid.UUID(self._value)
-        except ValueError:
-            self._errors = [self.ERROR_MESSAGE.format(self._value, self._key)]
-            return False
-        return True
 
 
 class Validator:

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -235,7 +235,7 @@ class TestRespondents(PartyTestClient):
             "telephone": "07837230942",
             "email_address": "a@b.com",
             "new_email_address": "a@b.com"
-            }
+        }
         self.change_respondent_details(respondent_id, payload, 200)
 
     def test_update_respondent_details_check_email(self):
@@ -247,7 +247,7 @@ class TestRespondents(PartyTestClient):
             "telephone": "07837230942",
             "email_address": "a@b.com",
             "new_email_address": "john.snow@thisemail.com"
-            }
+        }
         self.change_respondent_details(respondent_id, payload, 200)
 
     def test_update_respondent_details_respondent_does_not_exist_error(self):
@@ -258,7 +258,7 @@ class TestRespondents(PartyTestClient):
             "telephone": "07837230942",
             "email_address": "a@b.com",
             "new_email_address": "a@b.com"
-            }
+        }
         self.change_respondent_details(respondent_id, payload, 404)
 
     def test_resend_verification_email(self):


### PR DESCRIPTION
This PR strips more functionality from the validator class in favour of generating the error directly in the code.  This should make reading the code a easier.

Unit tests pass but acceptance tests haven't been run against it.  Early review on this would be useful however.