### PR TITLE
Performance improvement 650 concurrency

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -b 0.0.0.0:$PORT --workers 4 app:app
+web: gunicorn -b 0.0.0.0:$PORT --workers 8 app:app

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ def _is_true(value):
 class Config(object):
 
     NAME = os.getenv('RAS-PARTY', 'ras-party')
-    VERSION = os.getenv('VERSION', '1.2.0')
+    VERSION = os.getenv('VERSION', '1.2.1')
     SCHEME = os.getenv('http')
     HOST = os.getenv('HOST', '0.0.0.0')
     PORT = os.getenv('PORT', 8081)


### PR DESCRIPTION
# Motivation and Context
Performance Improvement

# What has changed
- Changing Gunicorn `sync` workers from 4 to 8.
- Requires 512M instance on cloud foundry environments.
- Incrementing version for release.

# How to test?
Has been load tested in Prunes. Just check the deployment pipeline is green after the changes are merged to `master`.

# Links
NA

# Screenshots (if appropriate):
