### PR TITLE
Remove mulitple calls to django Oauth

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -356,8 +356,8 @@ def put_email_verification(token, tran, session):
             logger.info('No pending enrolment for respondent while checking email verification token',
                         party_uuid=respondent.party_uuid)
 
-    # We set the user as verified on the OAuth2 server.
-    set_user_verified(email_address)
+        # We set the user as verified on the OAuth2 server.
+        set_user_verified(email_address)
 
     return respondent.to_respondent_dict()
 
@@ -372,7 +372,7 @@ def update_verified_email_address(respondent, tran, session):
     oauth_response = OauthClient().update_account(
         username=email_address,
         new_username=new_email_address,
-        account_verified='false')
+        account_verified='true')
 
     if oauth_response.status_code != 201:
         raise RasError("Failed to change respondent email")


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The verification endpoint has been implemented to be used for both initial account verification and email change verification.
The email change verification makes two calls to the django service one to change email and another to verify the account, this can be done in one call.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Remove additional call to django. Verify and change email in the same call.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check verifying newly created account and changing email address still works. 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
