### PR TITLE
Fix resend verification email

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -479,7 +479,7 @@ def _send_email_verification(party_id, email):
     Send an email verification to the respondent
     """
     verification_url = PublicWebsite().activate_account_url(email)
-    logger.info('Verification URL for party_id', party_id=party_id, url=verification_url, email=email)
+    logger.info('Verification URL for party_id', party_id=party_id, url=verification_url)
 
     personalisation = {
         'ACCOUNT_VERIFICATION_URL': verification_url

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -410,7 +410,10 @@ def resend_verification_email(party_uuid, session):
     if not respondent:
         raise RasError(NO_RESPONDENT_FOR_PARTY_ID, status=404)
 
-    _send_email_verification(party_uuid, respondent.email_address)
+    if respondent.pending_email_address != '':
+        _send_email_verification(party_uuid, respondent.pending_email_address)
+    else:
+        _send_email_verification(party_uuid, respondent.email_address)
 
     return {'message': EMAIL_VERIFICATION_SENT}
 
@@ -476,7 +479,7 @@ def _send_email_verification(party_id, email):
     Send an email verification to the respondent
     """
     verification_url = PublicWebsite().activate_account_url(email)
-    logger.info('Verification URL for party_id', party_id=party_id, url=verification_url)
+    logger.info('Verification URL for party_id', party_id=party_id, url=verification_url, email=email)
 
     personalisation = {
         'ACCOUNT_VERIFICATION_URL': verification_url

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -410,7 +410,7 @@ def resend_verification_email(party_uuid, session):
     if not respondent:
         raise RasError(NO_RESPONDENT_FOR_PARTY_ID, status=404)
 
-    if respondent.pending_email_address != '':
+    if respondent.pending_email_address:
         _send_email_verification(party_uuid, respondent.pending_email_address)
     else:
         _send_email_verification(party_uuid, respondent.email_address)

--- a/test/test_data/mock_respondent.py
+++ b/test/test_data/mock_respondent.py
@@ -104,3 +104,31 @@ class MockRespondentWithIdActive:
         props, attrs = partition_dict(self._attributes, ['id', 'sampleUnitType'])
         props['attributes'] = attrs
         return props
+
+
+class MockRespondentWithPendingEmail:
+    def __init__(self):
+        self._attributes = {
+            'id': '438df969-7c9c-4cd4-a89b-ac88cf0bfdf3',
+            'sampleUnitType': 'BI',
+            'firstName': 'A',
+            'lastName': 'Z',
+            'emailAddress': 'a@b.com',
+            'pendingEmailAddress': 'new@email.com',
+            'telephone': '123',
+            'enrolment_code': 'fb747cq725lj',
+            'password': 'banana',
+            'status': 'ACTIVE'
+        }
+
+    def attributes(self, **kwargs):
+        self._attributes.update(kwargs)
+        return self
+
+    def as_respondent(self):
+        return self._attributes
+
+    def as_party(self):
+        props, attrs = partition_dict(self._attributes, ['id', 'sampleUnitType'])
+        props['attributes'] = attrs
+        return props

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -46,6 +46,7 @@ class TestRespondents(PartyTestClient):
         translated_party = {
             'party_uuid': respondent.get('id') or str(uuid.uuid4()),
             'email_address': respondent['emailAddress'],
+            'pending_email_address': respondent.get('pendingEmailAddress'),
             'first_name': respondent['firstName'],
             'last_name': respondent['lastName'],
             'telephone': respondent['telephone'],
@@ -301,10 +302,11 @@ class TestRespondents(PartyTestClient):
         # When the resend verification email endpoint is hit
         self.resend_verification_email(respondent.party_uuid)
         # Then a notification message is sent to the pending email address and not the current one
+        pending_email = PublicWebsite().activate_account_url(respondent.pending_email_address)
         personalisation = {
-            'ACCOUNT_VERIFICATION_URL': PublicWebsite().activate_account_url(respondent.pending_email_address)
+            'ACCOUNT_VERIFICATION_URL': pending_email
         }
-        self.mock_notify.email_verification.assert_called_once_with(
+        self.mock_notify.verify_email.assert_called_once_with(
             respondent.pending_email_address,
             personalisation,
             respondent.party_uuid

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -296,6 +296,22 @@ class TestRespondents(PartyTestClient):
     def test_resend_verification_email_party_id_malformed(self):
         self.resend_verification_email('malformed', 500)
 
+    def test_resend_verification_email_sends_via_notify(self):
+        # Given there is an enrolled respondent
+        respondent = self.populate_with_respondent(respondent=self.mock_respondent_with_id)
+        # When the resend verification email endpoint is hit
+        self.resend_verification_email(respondent.party_uuid)
+        # Then a notification message is sent to the respondent's current email address
+        email = PublicWebsite().activate_account_url(respondent.email_address)
+        personalisation = {
+            'ACCOUNT_VERIFICATION_URL': email
+        }
+        self.mock_notify.verify_email.assert_called_once_with(
+            respondent.email_address,
+            personalisation,
+            respondent.party_uuid
+        )
+
     def test_resend_verification_email_sends_to_new_email_address(self):
         # Given there is a respondent with a pending email address
         respondent = self.populate_with_respondent(respondent=self.mock_respondent_with_pending_email)


### PR DESCRIPTION
# Motivation and Context
Service desk call TASK0241375

A bug exists where if a respondent has requested a change of email address then requested the verification email to be resent, the verification email was being sent to the user's old email address and the link did not work.

# How to test?
- Run alongside branch `fix-resend-verification-email-bug` in response-operations (https://github.com/ONSdigital/response-operations-ui/pull/203)

- Amend a current respondent's email address
- Verify the email by using the link in the party service logs
- The account should be verified:
The old email address should no longer work when logging in through frontstage
The respondent should be able to log in using the new email address
The email address should be updated against the respondent's details in response-ops

# Links
Trello card: https://trello.com/c/p6cE41dU
Related PR: https://github.com/ONSdigital/response-operations-ui/pull/203
