### PR TITLE
Fix logging levels

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -89,8 +89,8 @@ def post_respondent(party, tran, session):
     business = query_business_by_party_uuid(business_id, session)
     if not business:
         raise ClientError("Could not locate business when creating business association",
-                       business_id=business_id,
-                       status=404)
+                          business_id=business_id,
+                          status=404)
 
     # Chain of enrolment processes
     translated_party = {
@@ -159,7 +159,7 @@ def change_respondent_enrolment_status(payload, session):
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
         raise ClientError("Respondent does not exist.  Unable to change enrolment status",
-                       respondent_id=respondent_id, status=404)
+                          respondent_id=respondent_id, status=404)
 
     enrolment = query_enrolment_by_survey_business_respondent(respondent_id=respondent.id,
                                                               business_id=business_id,
@@ -241,7 +241,7 @@ def change_respondent_password(token, payload, tran, session):
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
         raise ClientError("Respondent does not exist.",
-                       status=404)
+                          status=404)
 
     new_password = payload['new_password']
 
@@ -317,7 +317,7 @@ def change_respondent_account_status(payload, party_id, session):
     respondent = query_respondent_by_party_uuid(party_id, session)
     if not respondent:
         raise ClientError("Respondent does not exist.  Unable to change account status.", respondent_id=party_id,
-                       status=404)
+                          status=404)
     respondent.status = status
 
 
@@ -462,8 +462,8 @@ def add_new_survey_for_respondent(payload, tran, session):
         business = query_business_by_party_uuid(business_id, session)
         if not business:
             raise ClientError("Could not locate business when creating business association.",
-                           business_id=business_id,
-                           status=404)
+                              business_id=business_id,
+                              status=404)
         br = BusinessRespondent(business=business, respondent=respondent)
 
     enrolment = Enrolment(business_respondent=br,

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -301,7 +301,7 @@ def request_password_change(payload, session):
                 email_address, personalisation, str(party_id))
         except RasNotifyError:
             # Note: intentionally suppresses exception
-            logger.error('Error sending reset password email for party_id', party_id=party_id)
+            logger.error('Error sending reset password email for respondent_id', respondent_id=party_id)
 
         logger.debug('Password reset email successfully sent', party_id=respondent.party_uuid)
 

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -54,7 +54,7 @@ def post_respondent(party, tran, session):
     if 'id' in party:
         # Note: there's not strictly a requirement to be able to pass in a UUID, this is currently supported to
         # aid with testing.
-        logger.debug("'id' in respondent post message.")
+        logger.debug("'id' in respondent post message")
         try:
             uuid.UUID(party['id'])
         except ValueError:
@@ -65,11 +65,11 @@ def post_respondent(party, tran, session):
 
     iac = request_iac(party['enrolmentCode'])
     if not iac.get('active'):
-        raise ClientError("Enrolment code is not active.", status=400)
+        raise ClientError("Enrolment code is not active", status=400)
 
     existing = query_respondent_by_email(party['emailAddress'], session)
     if existing:
-        raise ClientError("Email address already exists.",
+        raise ClientError("Email address already exists",
                           status=400,
                           party_uuid=str(existing.party_uuid))
 
@@ -158,7 +158,7 @@ def change_respondent_enrolment_status(payload, session):
                 status=change_flag)
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise ClientError("Respondent does not exist.  Unable to change enrolment status",
+        raise ClientError("Respondent does not exist",
                           respondent_id=respondent_id, status=404)
 
     enrolment = query_enrolment_by_survey_business_respondent(respondent_id=respondent.id,
@@ -188,14 +188,14 @@ def change_respondent(payload, session):
     respondent = query_respondent_by_email(email_address, session)
 
     if not respondent:
-        raise ClientError("Respondent does not exist.", status=404)
+        raise ClientError("Respondent does not exist", status=404)
 
     if new_email_address == email_address:
         return respondent.to_respondent_dict()
 
     respondent_with_new_email = query_respondent_by_email(new_email_address, session)
     if respondent_with_new_email:
-        raise ClientError("New email address already taken.", status=409)
+        raise ClientError("New email address already taken", status=409)
 
     respondent.pending_email_address = new_email_address
 
@@ -218,7 +218,7 @@ def verify_token(token, session):
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise ClientError("Respondent does not exist.", status=404)
+        raise ClientError("Respondent does not exist", status=404)
 
     return {'response': "Ok"}
 
@@ -240,7 +240,7 @@ def change_respondent_password(token, payload, tran, session):
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise ClientError("Respondent does not exist.",
+        raise ClientError("Respondent does not exist",
                           status=404)
 
     new_password = payload['new_password']
@@ -250,7 +250,7 @@ def change_respondent_password(token, payload, tran, session):
         password=new_password)
 
     if oauth_response.status_code != 201:
-        raise RasError("Failed to change respondent password.")
+        raise RasError("Failed to change respondent password")
 
     personalisation = {
         'FIRST_NAME': respondent.first_name
@@ -265,7 +265,7 @@ def change_respondent_password(token, payload, tran, session):
         logger.error('Error sending notification email', respondent_id=party_id)
 
     # This ensures the log message is only written once the DB transaction is committed
-    tran.on_success(lambda: logger.info('Respondent has changed their password', party_id=party_id))
+    tran.on_success(lambda: logger.info('Respondent has changed their password', respondent_id=party_id))
 
     return {'response': "Ok"}
 
@@ -280,7 +280,7 @@ def request_password_change(payload, session):
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise ClientError("Respondent does not exist.", status=404)
+        raise ClientError("Respondent does not exist", status=404)
 
     logger.debug("Requesting password change", party_id=respondent.party_uuid)
 
@@ -302,7 +302,7 @@ def request_password_change(payload, session):
                 email_address, personalisation, str(party_id))
         except RasNotifyError:
             # Note: intentionally suppresses exception
-            logger.error('Error sending request to Notify Gateway for respondent_id', respondent_id=party_id)
+            logger.error('Error sending request to Notify Gateway', respondent_id=party_id)
 
         logger.debug('Password reset email successfully sent', party_id=respondent.party_uuid)
 
@@ -316,7 +316,7 @@ def change_respondent_account_status(payload, party_id, session):
 
     respondent = query_respondent_by_party_uuid(party_id, session)
     if not respondent:
-        raise ClientError("Respondent does not exist.  Unable to change account status.", respondent_id=party_id,
+        raise ClientError("Respondent does not exist", respondent_id=party_id,
                           status=404)
     respondent.status = status
 
@@ -393,7 +393,7 @@ def update_verified_email_address(respondent, tran, session):
         if rollback_response.status_code != 201:
             logger.error("Failed to rollback change to respondent email. Please investigate.",
                          party_id=respondent.party_uuid)
-            raise RasError("Failed to rollback change to respondent email.")
+            raise RasError("Failed to rollback change to respondent email")
 
     tran.compensate(compensate_oauth_change)
 
@@ -439,7 +439,7 @@ def add_new_survey_for_respondent(payload, tran, session):
 
     iac = request_iac(enrolment_code)
     if not iac.get('active'):
-        raise ClientError("Enrolment code is not active.", status=400)
+        raise ClientError("Enrolment code is not active", status=400)
 
     respondent = query_respondent_by_party_uuid(respondent_party_id, session)
 
@@ -461,7 +461,7 @@ def add_new_survey_for_respondent(payload, tran, session):
         """
         business = query_business_by_party_uuid(business_id, session)
         if not business:
-            raise ClientError("Could not locate business when creating business association.",
+            raise ClientError("Could not locate business when creating business association",
                               business_id=business_id,
                               status=404)
         br = BusinessRespondent(business=business, respondent=respondent)

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -89,7 +89,7 @@ def post_respondent(party, tran, session):
     business = query_business_by_party_uuid(business_id, session)
     if not business:
         raise ClientError("Could not locate business when creating business association",
-                          business_id=str(business_id),
+                          business_id=business_id,
                           status=404)
 
     # Chain of enrolment processes
@@ -159,7 +159,7 @@ def change_respondent_enrolment_status(payload, session):
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
         raise ClientError("Respondent does not exist",
-                          respondent_id=str(respondent_id), status=404)
+                          respondent_id=respondent_id, status=404)
 
     enrolment = query_enrolment_by_survey_business_respondent(respondent_id=respondent.id,
                                                               business_id=business_id,
@@ -300,7 +300,7 @@ def request_password_change(payload, session):
 
         try:
             NotifyGateway(current_app.config).request_password_change(
-                email_address, personalisation, str(party_id))
+                email_address, personalisation, party_id)
         except RasNotifyError:
             # Note: intentionally suppresses exception
             logger.error('Error sending request to Notify Gateway', respondent_id=party_id)
@@ -317,7 +317,7 @@ def change_respondent_account_status(payload, party_id, session):
 
     respondent = query_respondent_by_party_uuid(party_id, session)
     if not respondent:
-        raise ClientError("Respondent does not exist", respondent_id=str(party_id),
+        raise ClientError("Respondent does not exist", respondent_id=party_id,
                           status=404)
     respondent.status = status
 
@@ -411,7 +411,7 @@ def resend_verification_email(party_uuid, session):
     :param party_uuid: the party uuid
     :return: make_response
     """
-    logger.debug('Attempting to resend verification_email', party_uuid=str(party_uuid))
+    logger.debug('Attempting to resend verification_email', party_uuid=party_uuid)
 
     respondent = query_respondent_by_party_uuid(party_uuid, session)
     if not respondent:
@@ -463,7 +463,7 @@ def add_new_survey_for_respondent(payload, tran, session):
         business = query_business_by_party_uuid(business_id, session)
         if not business:
             raise ClientError("Could not locate business when creating business association",
-                              business_id=str(business_id),
+                              business_id=business_id,
                               status=404)
         br = BusinessRespondent(business=business, respondent=respondent)
 
@@ -478,7 +478,7 @@ def add_new_survey_for_respondent(payload, tran, session):
     # This ensures the log message is only written once the DB transaction is committed
     tran.on_success(lambda: logger.info('Respondent has enroled to survey for business',
                                         survey_name=survey_name,
-                                        business=str(business_id)))
+                                        business=business_id))
 
 
 def _send_email_verification(party_id, email):

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -58,10 +58,10 @@ def post_respondent(party, tran, session):
         try:
             uuid.UUID(party['id'])
         except ValueError:
-            raise RasError(f"'{party['id']}' is not a valid UUID format for property 'id'", status=400)
+            raise ClientError(f"'{party['id']}' is not a valid UUID format for property 'id'", status=400)
 
     if not v.validate(party):
-        raise RasError(v.errors, 400)
+        raise ClientError(v.errors, 400)
 
     iac = request_iac(party['enrolmentCode'])
     if not iac.get('active'):
@@ -69,7 +69,9 @@ def post_respondent(party, tran, session):
 
     existing = query_respondent_by_email(party['emailAddress'], session)
     if existing:
-        raise ClientError("Email address already exists.", status=400, party_uuid=party.get('party_uuid', None))
+        raise ClientError("Email address already exists.",
+                          status=400,
+                          party_uuid=str(existing.party_uuid))
 
     case_context = request_case(party['enrolmentCode'])
     case_id = case_context['id']
@@ -82,11 +84,11 @@ def post_respondent(party, tran, session):
         survey = request_survey(survey_id)
         survey_name = survey['longName']
     except KeyError:
-        raise RasError("There is no survey bound for this user", party_uuid=party['party_uuid'])
+        raise ClientError("There is no survey bound for this user", party_uuid=party['party_uuid'])
 
     business = query_business_by_party_uuid(business_id, session)
     if not business:
-        raise RasError("Could not locate business when creating business association",
+        raise ClientError("Could not locate business when creating business association",
                        business_id=business_id,
                        status=404)
 
@@ -156,7 +158,7 @@ def change_respondent_enrolment_status(payload, session):
                 status=change_flag)
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise RasError("Respondent does not exist.  Unable to change enrolment status",
+        raise ClientError("Respondent does not exist.  Unable to change enrolment status",
                        respondent_id=respondent_id, status=404)
 
     enrolment = query_enrolment_by_survey_business_respondent(respondent_id=respondent.id,
@@ -178,7 +180,7 @@ def change_respondent(payload, session):
     """
     v = Validator(Exists('email_address', 'new_email_address'))
     if not v.validate(payload):
-        raise RasError(v.errors, 400)
+        raise ClientError(v.errors, 400)
 
     email_address = payload['email_address']
     new_email_address = payload['new_email_address']
@@ -186,8 +188,7 @@ def change_respondent(payload, session):
     respondent = query_respondent_by_email(email_address, session)
 
     if not respondent:
-        raise ClientError("Respondent does not exist.  Unable to amend repondent's email",
-                          status=404)
+        raise ClientError("Respondent does not exist.", status=404)
 
     if new_email_address == email_address:
         return respondent.to_respondent_dict()
@@ -213,11 +214,11 @@ def verify_token(token, session):
     except SignatureExpired:
         raise ClientError('Expired email verification token', status=409, token=token)
     except (BadSignature, BadData) as e:
-        raise RasError('Unknown email verification token', status=404, token=token, error=e)
+        raise ClientError('Unknown email verification token', status=404, token=token, error=e)
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise RasError("Respondent does not exist.  Unable to verify token.", status=404)
+        raise ClientError("Respondent does not exist.", status=404)
 
     return {'response': "Ok"}
 
@@ -227,7 +228,7 @@ def verify_token(token, session):
 def change_respondent_password(token, payload, tran, session):
     v = Validator(Exists('new_password'))
     if not v.validate(payload):
-        raise RasError(v.errors, 400)
+        raise ClientError(v.errors, 400)
 
     try:
         duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
@@ -235,11 +236,11 @@ def change_respondent_password(token, payload, tran, session):
     except SignatureExpired:
         raise ClientError('Expired email verification token', status=409, token=token)
     except (BadSignature, BadData) as e:
-        raise RasError('Unknown email verification token', status=404, token=token, error=e)
+        raise ClientError('Unknown email verification token', status=404, token=token, error=e)
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise RasError("Respondent does not exist. Unable to change respondent's password",
+        raise ClientError("Respondent does not exist.",
                        status=404)
 
     new_password = payload['new_password']
@@ -273,13 +274,13 @@ def change_respondent_password(token, payload, tran, session):
 def request_password_change(payload, session):
     v = Validator(Exists('email_address'))
     if not v.validate(payload):
-        raise RasError(v.errors, 400)
+        raise ClientError(v.errors, 400)
 
     email_address = payload['email_address']
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise ClientError("Respondent does not exist. Unable to request password change.", status=404)
+        raise ClientError("Respondent does not exist.", status=404)
 
     logger.debug("Requesting password change", party_id=respondent.party_uuid)
 
@@ -301,7 +302,7 @@ def request_password_change(payload, session):
                 email_address, personalisation, str(party_id))
         except RasNotifyError:
             # Note: intentionally suppresses exception
-            logger.error('Error sending reset password email for respondent_id', respondent_id=party_id)
+            logger.error('Error sending request to Notify Gateway for respondent_id', respondent_id=party_id)
 
         logger.debug('Password reset email successfully sent', party_id=respondent.party_uuid)
 
@@ -315,7 +316,7 @@ def change_respondent_account_status(payload, party_id, session):
 
     respondent = query_respondent_by_party_uuid(party_id, session)
     if not respondent:
-        raise RasError("Respondent does not exist.  Unable to change account status.", respondent_id=party_id,
+        raise ClientError("Respondent does not exist.  Unable to change account status.", respondent_id=party_id,
                        status=404)
     respondent.status = status
 
@@ -336,7 +337,7 @@ def put_email_verification(token, tran, session):
     except SignatureExpired:
         raise ClientError('Expired email verification token', status=409, token=token)
     except (BadSignature, BadData) as e:
-        raise RasError('Bad email verification token', status=404, token=token, error=e)
+        raise ClientError('Bad email verification token', status=404, token=token, error=e)
 
     respondent = query_respondent_by_email(email_address, session)
 
@@ -348,7 +349,7 @@ def put_email_verification(token, tran, session):
         if respondent:
             update_verified_email_address(respondent, tran, session)
         else:
-            raise RasError("Unable to find user while checking email verification token", status=404)
+            raise ClientError("Unable to find user while checking email verification token", status=404)
 
     if respondent.status != RespondentStatus.ACTIVE:
         # We set the party as ACTIVE in this service
@@ -413,7 +414,7 @@ def resend_verification_email(party_uuid, session):
 
     respondent = query_respondent_by_party_uuid(party_uuid, session)
     if not respondent:
-        raise RasError(NO_RESPONDENT_FOR_PARTY_ID, status=404)
+        raise ClientError(NO_RESPONDENT_FOR_PARTY_ID, status=404)
 
     if respondent.pending_email_address:
         _send_email_verification(party_uuid, respondent.pending_email_address)
@@ -460,7 +461,7 @@ def add_new_survey_for_respondent(payload, tran, session):
         """
         business = query_business_by_party_uuid(business_id, session)
         if not business:
-            raise RasError("Could not locate business when creating business association.",
+            raise ClientError("Could not locate business when creating business association.",
                            business_id=business_id,
                            status=404)
         br = BusinessRespondent(business=business, respondent=respondent)

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -67,7 +67,7 @@ def get_business_by_id(party_uuid, session, verbose=False, collection_exercise_i
 
     business = query_business_by_party_uuid(party_uuid, session)
     if not business:
-        raise ClientError("Business with party id does not exist", party_uuid=str(party_uuid), status=404)
+        raise ClientError("Business with party id does not exist", party_uuid=party_uuid, status=404)
 
     if verbose:
         return business.to_business_dict(collection_exercise_id=collection_exercise_id)

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -67,7 +67,7 @@ def get_business_by_id(party_uuid, session, verbose=False, collection_exercise_i
 
     business = query_business_by_party_uuid(party_uuid, session)
     if not business:
-        raise ClientError("Business with party id does not exist", party_uuid=party_uuid, status=404)
+        raise ClientError("Business with party id does not exist", party_uuid=str(party_uuid), status=404)
 
     if verbose:
         return business.to_business_dict(collection_exercise_id=collection_exercise_id)

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -6,7 +6,7 @@ from ras_party.controllers.queries import query_business_by_ref, query_business_
     query_businesses_by_party_uuids, search_businesses
 from ras_party.controllers.validate import Validator, Exists
 
-from ras_party.exceptions import RasError
+from ras_party.exceptions import ClientError, RasError
 from ras_party.models.models import Business, BusinessAttributes
 from ras_party.support.session_decorator import with_db_session
 
@@ -25,7 +25,7 @@ def get_business_by_ref(ref, session, verbose=False):
     """
     business = query_business_by_ref(ref, session)
     if not business:
-        raise RasError("Business with reference does not exist.", reference=ref, status=404)
+        raise ClientError("Business with reference does not exist.", reference=ref, status=404)
 
     if verbose:
         return business.to_business_dict()

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -39,7 +39,7 @@ def get_businesses_by_ids(party_uuids, session):
         try:
             uuid.UUID(party_uuid)
         except ValueError:
-            raise RasError(f"'{party_uuid}' is not a valid UUID format for property 'id'.", status=400)
+            raise ClientError(f"'{party_uuid}' is not a valid UUID format for property 'id'.", status=400)
 
     businesses = query_businesses_by_party_uuids(party_uuids, session)
     return [business.to_business_summary_dict() for business in businesses]
@@ -63,11 +63,11 @@ def get_business_by_id(party_uuid, session, verbose=False, collection_exercise_i
     try:
         uuid.UUID(party_uuid)
     except ValueError:
-        raise RasError(f"'{party_uuid}' is not a valid UUID format for property 'id'", status=400)
+        raise ClientError(f"'{party_uuid}' is not a valid UUID format for property 'id'", status=400)
 
     business = query_business_by_party_uuid(party_uuid, session)
     if not business:
-        raise RasError("Business with party id does not exist.", party_uuid=party_uuid, status=404)
+        raise ClientError("Business with party id does not exist.", party_uuid=party_uuid, status=404)
 
     if verbose:
         return business.to_business_dict(collection_exercise_id=collection_exercise_id)
@@ -89,7 +89,7 @@ def businesses_post(business_data, session):
     # FIXME: this is incorrect, it doesn't make sense to require sampleUnitType for the concrete endpoints
     errors = Business.validate(party_data, current_app.config['PARTY_SCHEMA'])
     if errors:
-        raise RasError([e.split('\n')[0] for e in errors], status=400)
+        raise ClientError([e.split('\n')[0] for e in errors], status=400)
 
     business = query_business_by_ref(party_data['sampleUnitRef'], session)
     if business:
@@ -114,7 +114,7 @@ def businesses_sample_ce_link(sample, ce_data, session):
 
     v = Validator(Exists('collectionExerciseId'))
     if not v.validate(ce_data):
-        raise RasError(v.errors, 400)
+        raise ClientError(v.errors, 400)
 
     collection_exercise_id = ce_data['collectionExerciseId']
 

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -25,7 +25,7 @@ def get_business_by_ref(ref, session, verbose=False):
     """
     business = query_business_by_ref(ref, session)
     if not business:
-        raise ClientError("Business with reference does not exist.", reference=ref, status=404)
+        raise ClientError("Business with reference does not exist", reference=ref, status=404)
 
     if verbose:
         return business.to_business_dict()
@@ -39,7 +39,7 @@ def get_businesses_by_ids(party_uuids, session):
         try:
             uuid.UUID(party_uuid)
         except ValueError:
-            raise ClientError(f"'{party_uuid}' is not a valid UUID format for property 'id'.", status=400)
+            raise ClientError(f"'{party_uuid}' is not a valid UUID format for property 'id'", status=400)
 
     businesses = query_businesses_by_party_uuids(party_uuids, session)
     return [business.to_business_summary_dict() for business in businesses]
@@ -67,7 +67,7 @@ def get_business_by_id(party_uuid, session, verbose=False, collection_exercise_i
 
     business = query_business_by_party_uuid(party_uuid, session)
     if not business:
-        raise ClientError("Business with party id does not exist.", party_uuid=party_uuid, status=404)
+        raise ClientError("Business with party id does not exist", party_uuid=party_uuid, status=404)
 
     if verbose:
         return business.to_business_dict(collection_exercise_id=collection_exercise_id)

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -6,7 +6,7 @@ from ras_party.controllers.queries import query_business_by_ref, query_business_
     query_businesses_by_party_uuids, search_businesses
 from ras_party.controllers.validate import Validator, Exists
 
-from ras_party.exceptions import ClientError, RasError
+from ras_party.exceptions import ClientError
 from ras_party.models.models import Business, BusinessAttributes
 from ras_party.support.session_decorator import with_db_session
 

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -44,7 +44,8 @@ def get_party_by_ref(sample_unit_type, sample_unit_ref, session):
     :rtype: Party
     """
     if sample_unit_type != Business.UNIT_TYPE:
-        raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B']", status=400)
+        raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B']",
+                          status=400)
     business = query_business_by_ref(sample_unit_ref, session)
     if not business:
         raise ClientError("Business with reference does not exist.", refernce=sample_unit_ref, status=404)
@@ -66,7 +67,7 @@ def get_party_by_id(sample_unit_type, id, session):
         return respondent.to_party_dict()
     else:
         raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']",
-                       status=400)
+                          status=400)
 
 
 def get_business_with_respondents_filtered_by_survey(sample_unit_type, id, survey_id):

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -58,12 +58,12 @@ def get_party_by_id(sample_unit_type, id, session):
     if sample_unit_type == Business.UNIT_TYPE:
         business = query_business_by_party_uuid(id, session)
         if not business:
-            raise ClientError("Business with id does not exist", business_id=str(id), status=404)
+            raise ClientError("Business with id does not exist", business_id=id, status=404)
         return business.to_party_dict()
     elif sample_unit_type == Respondent.UNIT_TYPE:
         respondent = query_respondent_by_party_uuid(id, session)
         if not respondent:
-            raise ClientError("Respondent with id does not exist", respondent_id=str(id), status=404)
+            raise ClientError("Respondent with id does not exist", respondent_id=id, status=404)
         return respondent.to_party_dict()
     else:
         raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']",

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -2,7 +2,7 @@ from flask import current_app
 
 from ras_party.controllers.queries import query_business_by_party_uuid, query_business_by_ref
 from ras_party.controllers.queries import query_respondent_by_party_uuid
-from ras_party.exceptions import RasError
+from ras_party.exceptions import ClientError
 from ras_party.models.models import Business, Respondent
 from ras_party.support.session_decorator import with_db_session
 
@@ -17,10 +17,10 @@ def parties_post(party_data, session):
     """
     errors = Business.validate(party_data, current_app.config['PARTY_SCHEMA'])
     if errors:
-        raise RasError([e.split('\n')[0] for e in errors], status=400)
+        raise ClientError([e.split('\n')[0] for e in errors], status=400)
 
     if party_data['sampleUnitType'] != Business.UNIT_TYPE:
-        raise RasError('sampleUnitType must be of type', type=Business.UNIT_TYPE, status=400)
+        raise ClientError('sampleUnitType must be of type', type=Business.UNIT_TYPE, status=400)
 
     business = query_business_by_ref(party_data['sampleUnitRef'], session)
     if business:
@@ -44,10 +44,10 @@ def get_party_by_ref(sample_unit_type, sample_unit_ref, session):
     :rtype: Party
     """
     if sample_unit_type != Business.UNIT_TYPE:
-        raise RasError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B']", status=400)
+        raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B']", status=400)
     business = query_business_by_ref(sample_unit_ref, session)
     if not business:
-        raise RasError("Business with reference does not exist.", refernce=sample_unit_ref, status=404)
+        raise ClientError("Business with reference does not exist.", refernce=sample_unit_ref, status=404)
 
     return business.to_party_dict()
 
@@ -57,15 +57,15 @@ def get_party_by_id(sample_unit_type, id, session):
     if sample_unit_type == Business.UNIT_TYPE:
         business = query_business_by_party_uuid(id, session)
         if not business:
-            raise RasError("Business with id does not exist.", business_id=id, status=404)
+            raise ClientError("Business with id does not exist.", business_id=id, status=404)
         return business.to_party_dict()
     elif sample_unit_type == Respondent.UNIT_TYPE:
         respondent = query_respondent_by_party_uuid(id, session)
         if not respondent:
-            raise RasError("Respondent with id does not exist.", respondent_id=id, status=404)
+            raise ClientError("Respondent with id does not exist.", respondent_id=id, status=404)
         return respondent.to_party_dict()
     else:
-        raise RasError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']",
+        raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']",
                        status=400)
 
 

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -58,12 +58,12 @@ def get_party_by_id(sample_unit_type, id, session):
     if sample_unit_type == Business.UNIT_TYPE:
         business = query_business_by_party_uuid(id, session)
         if not business:
-            raise ClientError("Business with id does not exist.", business_id=id, status=404)
+            raise ClientError("Business with id does not exist", business_id=id, status=404)
         return business.to_party_dict()
     elif sample_unit_type == Respondent.UNIT_TYPE:
         respondent = query_respondent_by_party_uuid(id, session)
         if not respondent:
-            raise ClientError("Respondent with id does not exist.", respondent_id=id, status=404)
+            raise ClientError("Respondent with id does not exist", respondent_id=id, status=404)
         return respondent.to_party_dict()
     else:
         raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']",

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -58,12 +58,12 @@ def get_party_by_id(sample_unit_type, id, session):
     if sample_unit_type == Business.UNIT_TYPE:
         business = query_business_by_party_uuid(id, session)
         if not business:
-            raise ClientError("Business with id does not exist", business_id=id, status=404)
+            raise ClientError("Business with id does not exist", business_id=str(id), status=404)
         return business.to_party_dict()
     elif sample_unit_type == Respondent.UNIT_TYPE:
         respondent = query_respondent_by_party_uuid(id, session)
         if not respondent:
-            raise ClientError("Respondent with id does not exist", respondent_id=id, status=404)
+            raise ClientError("Respondent with id does not exist", respondent_id=str(id), status=404)
         return respondent.to_party_dict()
     else:
         raise ClientError(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']",

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -78,7 +78,7 @@ def change_respondent_details(respondent_data, respondent_id, session):
 
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise ClientError("Respondent id does not exist", respondent_id=respondent_id, status=404)
+        raise ClientError("Respondent id does not exist", respondent_id=str(respondent_id), status=404)
 
     # This function updates the name and number of a respondent
     update_respondent_details(respondent_data, respondent_id, session)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -78,7 +78,7 @@ def change_respondent_details(respondent_data, respondent_id, session):
 
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise ClientError("Respondent id does not exist", respondent_id=str(respondent_id), status=404)
+        raise ClientError("Respondent id does not exist", respondent_id=respondent_id, status=404)
 
     # This function updates the name and number of a respondent
     update_respondent_details(respondent_data, respondent_id, session)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -22,7 +22,7 @@ def get_respondent_by_ids(ids, session):
         try:
             uuid.UUID(party_id)
         except ValueError:
-            raise ClientError(f"'{party_id}' is not a valid UUID format for property 'id'.", status=400)
+            raise ClientError(f"'{party_id}' is not a valid UUID format for property 'id'", status=400)
 
     respondents = query_respondent_by_party_uuids(ids, session)
     return [respondent.to_respondent_dict() for respondent in respondents]
@@ -41,11 +41,11 @@ def get_respondent_by_id(id, session):
     try:
         uuid.UUID(id)
     except ValueError:
-        raise ClientError(f"'{id}' is not a valid UUID format for property 'id'.", status=400)
+        raise ClientError(f"'{id}' is not a valid UUID format for property 'id'", status=400)
 
     respondent = query_respondent_by_party_uuid(id, session)
     if not respondent:
-        raise ClientError("Respondent with party id does not exist.", respondent_id=id, status=404)
+        raise ClientError("Respondent with party id does not exist", respondent_id=id, status=404)
 
     return respondent.to_respondent_dict()
 
@@ -62,7 +62,7 @@ def get_respondent_by_email(email, session):
     """
     respondent = query_respondent_by_email(email, session)
     if not respondent:
-        raise ClientError("Respondent does not exist.", status=404)
+        raise ClientError("Respondent does not exist", status=404)
 
     return respondent.to_respondent_dict()
 
@@ -78,7 +78,7 @@ def change_respondent_details(respondent_data, respondent_id, session):
 
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise ClientError("Respondent id does not exist.", respondent_id=respondent_id, status=404)
+        raise ClientError("Respondent id does not exist", respondent_id=respondent_id, status=404)
 
     # This function updates the name and number of a respondent
     update_respondent_details(respondent_data, respondent_id, session)

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -3,7 +3,7 @@ import uuid
 from ras_party.controllers.queries import query_respondent_by_party_uuid, \
     query_respondent_by_email, update_respondent_details, query_respondent_by_party_uuids
 
-from ras_party.exceptions import RasError
+from ras_party.exceptions import ClientError
 from ras_party.support.session_decorator import with_db_session
 from ras_party.controllers.account_controller import change_respondent
 
@@ -22,7 +22,7 @@ def get_respondent_by_ids(ids, session):
         try:
             uuid.UUID(party_id)
         except ValueError:
-            raise RasError(f"'{party_id}' is not a valid UUID format for property 'id'.", status=400)
+            raise ClientError(f"'{party_id}' is not a valid UUID format for property 'id'.", status=400)
 
     respondents = query_respondent_by_party_uuids(ids, session)
     return [respondent.to_respondent_dict() for respondent in respondents]
@@ -41,11 +41,11 @@ def get_respondent_by_id(id, session):
     try:
         uuid.UUID(id)
     except ValueError:
-        raise RasError(f"'{id}' is not a valid UUID format for property 'id'.", status=400)
+        raise ClientError(f"'{id}' is not a valid UUID format for property 'id'.", status=400)
 
     respondent = query_respondent_by_party_uuid(id, session)
     if not respondent:
-        raise RasError("Respondent with party id does not exist.", respondent_id=id, status=404)
+        raise ClientError("Respondent with party id does not exist.", respondent_id=id, status=404)
 
     return respondent.to_respondent_dict()
 
@@ -62,7 +62,7 @@ def get_respondent_by_email(email, session):
     """
     respondent = query_respondent_by_email(email, session)
     if not respondent:
-        raise RasError("Respondent does not exist.", status=404)
+        raise ClientError("Respondent does not exist.", status=404)
 
     return respondent.to_respondent_dict()
 
@@ -78,7 +78,7 @@ def change_respondent_details(respondent_data, respondent_id, session):
 
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise RasError("Respondent id does not exist.", respondent_id=respondent_id, status=404)
+        raise ClientError("Respondent id does not exist.", respondent_id=respondent_id, status=404)
 
     # This function updates the name and number of a respondent
     update_respondent_details(respondent_data, respondent_id, session)

--- a/ras_party/error_handlers.py
+++ b/ras_party/error_handlers.py
@@ -46,7 +46,6 @@ def http_error(error):
         response.status_code = 500
     logger.exception('Uncaught exception',
                      url=request.url,
-                     api_url=error.url,
                      errors=errors,
                      status=response.status_code)
     return response

--- a/ras_party/error_handlers.py
+++ b/ras_party/error_handlers.py
@@ -2,7 +2,7 @@ import logging
 
 import flask
 import structlog
-from flask import jsonify
+from flask import jsonify, request
 from requests import RequestException
 
 from ras_party.exceptions import ClientError, RasError
@@ -16,7 +16,11 @@ blueprint = flask.Blueprint('error_handlers', __name__)
 def client_error(error):
     response = jsonify(error.to_dict())
     response.status_code = error.status_code
-    logger.info('Client error', errors=error.to_dict(), status=error.status_code)
+    logger.info('Client error',
+                url=request.url,
+                errors=error.to_dict(),
+                **error.kwargs,
+                status=error.status_code)
     return response
 
 
@@ -24,7 +28,11 @@ def client_error(error):
 def ras_error(error):
     response = jsonify(error.to_dict())
     response.status_code = error.status_code
-    logger.exception('Uncaught exception', errors=error.to_dict(), status=error.status_code)
+    logger.exception('Uncaught exception',
+                     url=request.url,
+                     errors=error.to_dict(),
+                     **error.kwargs,
+                     status=error.status_code)
     return response
 
 
@@ -36,7 +44,11 @@ def http_error(error):
         response.status_code = error.response.status_code
     else:
         response.status_code = 500
-    logger.exception('Uncaught exception', errors=errors, status=response.status_code)
+    logger.exception('Uncaught exception',
+                     url=request.url,
+                     api_url=error.url,
+                     errors=errors,
+                     status=response.status_code)
     return response
 
 

--- a/ras_party/error_handlers.py
+++ b/ras_party/error_handlers.py
@@ -5,11 +5,19 @@ import structlog
 from flask import jsonify
 from requests import RequestException
 
-from ras_party.exceptions import RasError
+from ras_party.exceptions import ClientError, RasError
 
 logger = structlog.wrap_logger(logging.getLogger(__name__))
 
 blueprint = flask.Blueprint('error_handlers', __name__)
+
+
+@blueprint.app_errorhandler(ClientError)
+def client_error(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    logger.info('Client error', errors=error.to_dict(), status=error.status_code)
+    return response
 
 
 @blueprint.app_errorhandler(RasError)

--- a/ras_party/error_handlers.py
+++ b/ras_party/error_handlers.py
@@ -19,8 +19,8 @@ def client_error(error):
     logger.info('Client error',
                 url=request.url,
                 errors=error.to_dict(),
-                **error.kwargs,
-                status=error.status_code)
+                status=error.status_code,
+                **error.kwargs)
     return response
 
 
@@ -31,8 +31,8 @@ def ras_error(error):
     logger.exception('Uncaught exception',
                      url=request.url,
                      errors=error.to_dict(),
-                     **error.kwargs,
-                     status=error.status_code)
+                     status=error.status_code,
+                     **error.kwargs)
     return response
 
 

--- a/ras_party/exceptions.py
+++ b/ras_party/exceptions.py
@@ -1,3 +1,15 @@
+class ClientError(Exception):
+
+    status_code = 400
+
+    def __init__(self, errors, status=None, **kwargs):
+        self.errors = errors if isinstance(errors, list) else [errors]
+        self.status_code = status or RasPartyError.status_code
+        self.kwargs = kwargs
+
+    def to_dict(self):
+        return {'errors': self.errors}
+
 
 class RasError(Exception):
 

--- a/ras_party/exceptions.py
+++ b/ras_party/exceptions.py
@@ -1,8 +1,6 @@
 class ClientError(Exception):
 
-    status_code = 400
-
-    def __init__(self, errors, status=None, **kwargs):
+    def __init__(self, errors, status=400, **kwargs):
         self.errors = errors if isinstance(errors, list) else [errors]
         self.status_code = status or RasPartyError.status_code
         self.kwargs = kwargs

--- a/ras_party/support/session_decorator.py
+++ b/ras_party/support/session_decorator.py
@@ -22,11 +22,11 @@ def handle_session(f, args, kwargs):
         session.commit()
         return result
     except ClientError:
-        logger.info(f"Rolling back database session due to a ClientError")
+        logger.info("Rolling back database session due to a ClientError")
         session.rollback()
         raise
     except RasError:
-        logger.info(f"Rolling back database session due to failure executing function")
+        logger.info("Rolling back database session due to failure executing function")
         session.rollback()
         raise
     except Exception:

--- a/test/test_error_handlers.py
+++ b/test/test_error_handlers.py
@@ -1,3 +1,5 @@
+from flask import request
+
 from unittest.mock import patch
 
 from requests import Request, RequestException, Response
@@ -11,14 +13,14 @@ class TestErrorHandlers(PartyTestClient):
 
     def test_uncaught_client_error_handler_will_log_exception(self):
         # Given
-        error = ClientError(errors=['some error'], status=400)
+        error = ClientError(errors=['some error'], status=400, )
 
         with patch('ras_party.error_handlers.logger') as logger:
             # When
             client_error(error)
             # Then
             logger.info.assert_called_once_with('Client error', errors={'errors': ['some error']},
-                                                status=400)
+                                                status=400, url=request.url)
 
     def test_uncaught_ras_error_handler(self):
         # Given
@@ -39,7 +41,8 @@ class TestErrorHandlers(PartyTestClient):
 
             # Then
             logger.exception.assert_called_once_with('Uncaught exception', errors={'errors': ['some error']},
-                                                     status=418)
+                                                     status=418,
+                                                     url=request.url)
 
     def test_uncaught_request_exception_handler(self):
         # Given
@@ -63,7 +66,8 @@ class TestErrorHandlers(PartyTestClient):
             # Then
             logger.exception.assert_called_once_with('Uncaught exception',
                                                      errors={'errors': {'method': 'GET', 'url': 'http://localhost'}},
-                                                     status=500)
+                                                     status=500,
+                                                     url=request.url)
 
     def test_uncaught_exception_handler(self):
         # Given

--- a/test/test_error_handlers.py
+++ b/test/test_error_handlers.py
@@ -1,13 +1,24 @@
 from unittest.mock import patch
 
-from requests import RequestException, Request, Response
+from requests import Request, RequestException, Response
 
-from ras_party.error_handlers import ras_error, exception_error, http_error
-from ras_party.exceptions import RasError
+from ras_party.error_handlers import client_error, exception_error, http_error, ras_error
+from ras_party.exceptions import ClientError, RasError
 from test.party_client import PartyTestClient
 
 
 class TestErrorHandlers(PartyTestClient):
+
+    def test_uncaught_client_error_handler_will_log_exception(self):
+        # Given
+        error = ClientError(errors=['some error'], status=400)
+
+        with patch('ras_party.error_handlers.logger') as logger:
+            # When
+            client_error(error)
+            # Then
+            logger.info.assert_called_once_with('Client error', errors={'errors': ['some error']},
+                                                status=400)
 
     def test_uncaught_ras_error_handler(self):
         # Given

--- a/test/test_error_handlers.py
+++ b/test/test_error_handlers.py
@@ -11,7 +11,8 @@ from test.party_client import PartyTestClient
 
 class TestErrorHandlers(PartyTestClient):
 
-    def test_uncaught_client_error_handler_will_log_exception(self):
+    @staticmethod
+    def test_uncaught_client_error_handler_will_log_exception():
         # Given
         error = ClientError(errors=['some error'], status=400, )
 

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -105,7 +105,7 @@ class TestParties(PartyTestClient):
     def test_get_business_by_ids_fails_if_id_is_not_uuid(self):
         party_uuid = "gibberish"
         response = self.get_businesses_by_ids([party_uuid], expected_status=400)
-        self.assertEquals(response['errors'][0], """'gibberish' is not a valid UUID format for property 'id'.""")
+        self.assertEquals(response['errors'][0], """'gibberish' is not a valid UUID format for property 'id'""")
 
     def test_get_business_by_id_with_no_active_attributes_returns_404(self):
         mock_business = MockBusiness() \

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -8,7 +8,7 @@ from itsdangerous import URLSafeTimedSerializer
 
 from ras_party.controllers import account_controller
 from ras_party.controllers.queries import query_respondent_by_party_uuid, query_business_by_party_uuid
-from ras_party.exceptions import RasError
+from ras_party.exceptions import ClientError
 from ras_party.models.models import BusinessRespondent, Enrolment, RespondentStatus, Respondent
 from ras_party.support.public_website import PublicWebsite
 from ras_party.support.requests_wrapper import Requests
@@ -750,7 +750,7 @@ class TestRespondents(PartyTestClient):
                 'enrolmentCode': 'abc'
             }
             query('test@example.test', db.session()).return_value = None
-            with self.assertRaises(RasError):
+            with self.assertRaises(ClientError):
                 account_controller.post_respondent(payload)
             query.assert_called_once_with('test@example.test', db.session())
 

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -166,7 +166,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent()
         party_uuid = "gibberish"
         response = self.get_respondents_by_ids([party_uuid], expected_status=400)
-        self.assertEquals(response['errors'][0], """'gibberish' is not a valid UUID format for property 'id'.""")
+        self.assertEquals(response['errors'][0], """'gibberish' is not a valid UUID format for property 'id'""")
 
     def test_get_respondent_by_ids_with_an_unknown_id_still_returns_correct_representation_for_other_ids(self):
         respondent_1 = MockRespondent()


### PR DESCRIPTION
# Motivation and Context
There are a lot of errors/exceptions being reported in Splunk that aren't actual errors (e.g. someone typing in an enrolment code wrong isn't a problem with the application).  This work changes the logging levels to 'info' for exceptions that have no negative impact.

**This work only covers the logging levels - there's another piece of work to improve and  standardise the way that exceptions are raised and errors are logged across all services but a card has been raised to cover it. **

# What has changed
- Made some error messages more explicit to help when diagnosing errors in Splunk.
- Changed log levels to 'info' where appropriate
- Set up a new ClientError exception to log some exceptions at 'info' level
- Added new tests to cover the ClientError exception

# How to test?
- Tests should pass
- Generate a few exceptions.  They should be logging at 'info' level where appropriate.

