### PR TITLE
Remove references of survey_name across service

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,7 +21,6 @@ This page documents the Party service API endpoints. All endpoints return an `HT
         "enrolments": [
             {
                 "enrolmentStatus": "ENABLED",
-                "name": "Business Register and Employment Survey",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
             }
         ],
@@ -78,7 +77,6 @@ This page documents the Party service API endpoints. All endpoints return an `HT
         "enrolments": [
             {
                 "enrolmentStatus": "ENABLED",
-                "name": "Business Register and Employment Survey",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
             }
         ],
@@ -106,7 +104,6 @@ This page documents the Party service API endpoints. All endpoints return an `HT
         "enrolments": [
             {
                 "enrolmentStatus": "ENABLED",
-                "name": "Business Register and Employment Survey",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
             }
         ],
@@ -161,7 +158,6 @@ This page documents the Party service API endpoints. All endpoints return an `HT
         "enrolments": [
             {
                 "enrolmentStatus": "ENABLED",
-                "name": "Business Register and Employment Survey",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
             }
         ],
@@ -180,7 +176,6 @@ This page documents the Party service API endpoints. All endpoints return an `HT
         "enrolments": [
             {
                 "enrolmentStatus": "ENABLED",
-                "name": "Business Register and Employment Survey",
                 "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
             }
         ],
@@ -208,7 +203,6 @@ This page documents the Party service API endpoints. All endpoints return an `HT
             "enrolments": [
                 {
                     "enrolmentStatus": "ENABLED",
-                    "name": "Business Register and Employment Survey",
                     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
                 }
             ],
@@ -244,7 +238,6 @@ The pendingEmailAddress field holds the unverified email address when it is bein
             "enrolments": [
                 {
                     "enrolmentStatus": "ENABLED",
-                    "name": "Business Register and Employment Survey",
                     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
                 }
             ],
@@ -275,7 +268,6 @@ The pendingEmailAddress field holds the unverified email address when it is bein
             "enrolments": [
                 {
                     "enrolmentStatus": "ENABLED",
-                    "name": "Business Register and Employment Survey",
                     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
                 }
             ],
@@ -298,7 +290,6 @@ The pendingEmailAddress field holds the unverified email address when it is bein
             "enrolments": [
                 {
                     "enrolmentStatus": "ENABLED",
-                    "name": "Business Register and Employment Survey",
                     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
                 }
             ],

--- a/migrations/versions/613bf3a40948_remove_survey_name.py
+++ b/migrations/versions/613bf3a40948_remove_survey_name.py
@@ -1,0 +1,23 @@
+"""remove survey name
+
+Revision ID: 613bf3a40948
+Revises: ac604d2cf763
+Create Date: 2018-08-20 10:16:35.995473
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '613bf3a40948'
+down_revision = 'ac604d2cf763'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    op.drop_column('survey_name', schema='partysvc.enrolment')

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -83,8 +83,6 @@ def post_respondent(party, tran, session):
 
     try:
         survey_id = collection_exercise['surveyId']
-        survey = request_survey(survey_id)
-        survey_name = survey['longName']
     except KeyError:
         raise ClientError("There is no survey bound for this user", party_uuid=party['party_uuid'])
 
@@ -114,7 +112,6 @@ def post_respondent(party, tran, session):
                                              survey_id=survey_id)
         Enrolment(business_respondent=br,
                   survey_id=survey_id,
-                  survey_name=survey_name,
                   status=EnrolmentStatus.PENDING)
         session.add(respondent)
         session.add(pending_enrolment)
@@ -466,8 +463,6 @@ def add_new_survey_for_respondent(payload, tran, session):
     collection_exercise = request_collection_exercise(collection_exercise_id)
 
     survey_id = collection_exercise['surveyId']
-    survey = request_survey(survey_id)
-    survey_name = survey['longName']
 
     br = query_business_respondent_by_respondent_id_and_business_id(business_id, respondent.id, session)
 
@@ -484,7 +479,6 @@ def add_new_survey_for_respondent(payload, tran, session):
 
     enrolment = Enrolment(business_respondent=br,
                           survey_id=survey_id,
-                          survey_name=survey_name,
                           status=EnrolmentStatus.ENABLED)
     session.add(enrolment)
 
@@ -492,7 +486,6 @@ def add_new_survey_for_respondent(payload, tran, session):
 
     # This ensures the log message is only written once the DB transaction is committed
     tran.on_success(lambda: logger.info('Respondent has enroled to survey for business',
-                                        survey_name=survey_name,
                                         business=business_id))
 
 

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -88,7 +88,6 @@ class Business(Base):
             respondent_dict['enrolments'] = []
             for enrolment in enrolments:
                 enrolments_dict = {
-                    "name": enrolment.survey_name,
                     "surveyId": enrolment.survey_id,
                     "enrolmentStatus": EnrolmentStatus(enrolment.status).name
                 }
@@ -250,7 +249,6 @@ class Respondent(Base):
             business_dict['enrolments'] = []
             for enrolment in enrolments:
                 enrolments_dict = {
-                    "name": enrolment.survey_name,
                     "surveyId": enrolment.survey_id,
                     "enrolmentStatus": EnrolmentStatus(enrolment.status).name
                 }
@@ -302,7 +300,6 @@ class Enrolment(Base):
     business_id = Column(GUID, primary_key=True)
     respondent_id = Column(Integer, primary_key=True)
     survey_id = Column(Text, primary_key=True)
-    survey_name = Column(Text)
     status = Column('status', Enum(EnrolmentStatus), default=EnrolmentStatus.PENDING)
     created_on = Column(DateTime, default=datetime.datetime.utcnow)
 

--- a/test/test_data/mock_enrolment.py
+++ b/test/test_data/mock_enrolment.py
@@ -4,7 +4,6 @@ class MockEnrolmentEnabled:
             'business_id': '3b136c4b-7a14-4904-9e01-13364dd7b972',
             'respondent_id': '1',
             'survey_id': '02b9c366-7397-42f7-942a-76dc5876d86d',
-            'survey_name': 'Quarterly Business Survey',
             'status': 'ENABLED',
             'created_on': "2017-12-01 13:40:55.495895"
         }
@@ -23,7 +22,6 @@ class MockEnrolmentDisabled:
             'business_id': '3b136c4b-7a14-4904-9e01-13364dd7b972',
             'respondent_id': '1',
             'survey_id': '02b9c366-7397-42f7-942a-76dc5876d86d',
-            'survey_name': 'Quarterly Business Survey',
             'status': 'DISABLED',
             'created_on': "2017-12-01 13:40:55.495895"
         }

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -65,7 +65,6 @@ class TestRespondents(PartyTestClient):
             'business_id': enrolment['business_id'],
             'respondent_id': enrolment['respondent_id'],
             'survey_id': enrolment['survey_id'],
-            'survey_name': enrolment['survey_name'],
             'status': enrolment['status'],
             'created_on': enrolment['created_on']
         }


### PR DESCRIPTION
### What is the Context of this PR?

In context of this PR is very similar to: https://github.com/ONSdigital/rm-collection-exercise-service/pull/113

Since the service name can be edited now, the one held in this service is not even the correct one i.e. out of date and the actual up to date survey details are stored in another service i.e. survey service

Card: https://trello.com/c/LP687BIU/331-remove-repeated-survey-name-from-services-other-than-survey-service-s

This PR aims to remove any ref of the survey name and drop the column entirely from the DB as well by adding a new script.

### How to Review
- Verify all instances of survey name are removed and any code referencing it.
- Check all tests pass and that the new alembic script works. 
- Ensure all functionality works as per norm