### PR TITLE
ZipKin Tracing - Alternative Approach

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,8 @@ retrying = "==1.3.3"
 sqlalchemy = "==1.1.10"
 sqlalchemy-utils = "==0.32.14"
 structlog = "==17.2.0"
+requests-middleware = "*"
+flask-zipkin = "*"
 
 [dev-packages]
 coverage = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a62ae2e8745377dbe0ed755f57cdea4fd045b96a9125fbbaecadf1169790460b"
+            "sha256": "2a78091702108cfad6c5cf70d5e3b0aa1ad793249e8d55bdc911791601257359"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,12 +23,19 @@
             "index": "pypi",
             "version": "==0.9.6"
         },
+        "cachetools": {
+            "hashes": [
+                "sha256:90f1d559512fc073483fe573ef5ceb39bf6ad3d39edc98dc55178a2b2b176fa3",
+                "sha256:d1c398969c478d336f767ba02040fa22617333293fb0b8968e79b16028dfee35"
+            ],
+            "version": "==2.1.0"
+        },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
+                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.8.13"
         },
         "cfenv": {
             "hashes": [
@@ -77,11 +84,19 @@
             "index": "pypi",
             "version": "==3.2.3"
         },
+        "flask-zipkin": {
+            "hashes": [
+                "sha256:402bed9a98d3507d82db98a8f7437fb52ef3684af33c58a241b37779f9013d74",
+                "sha256:fbd3e3c41ceeda922701eebbfce88c8fccb7bc849289d772f5186a14a49827bd"
+            ],
+            "index": "pypi",
+            "version": "==0.0.4"
+        },
         "furl": {
             "hashes": [
-                "sha256:47b25a4c4e48d926c399a5538466134fc7aed8b357a6290dcb83e3a1b9f3aa29"
+                "sha256:5436226c89536b5fa8c5faa1e34d684d417f69dea91d406edaab102c5da6de8c"
             ],
-            "version": "==1.1"
+            "version": "==1.2"
         },
         "gevent": {
             "hashes": [
@@ -112,26 +127,28 @@
         },
         "greenlet": {
             "hashes": [
-                "sha256:09ef2636ea35782364c830f07127d6c7a70542b178268714a9a9ba16318e7e8b",
-                "sha256:0fef83d43bf87a5196c91e73cb9772f945a4caaff91242766c5916d1dd1381e4",
-                "sha256:1b7df09c6598f5cfb40f843ade14ed1eb40596e75cd79b6fa2efc750ba01bb01",
-                "sha256:1fff21a2da5f9e03ddc5bd99131a6b8edf3d7f9d6bc29ba21784323d17806ed7",
-                "sha256:42118bf608e0288e35304b449a2d87e2ba77d1e373e8aa221ccdea073de026fa",
-                "sha256:50643fd6d54fd919f9a0a577c5f7b71f5d21f0959ab48767bd4bb73ae0839500",
-                "sha256:58798b5d30054bb4f6cf0f712f08e6092df23a718b69000786634a265e8911a9",
-                "sha256:5b49b3049697aeae17ef7bf21267e69972d9e04917658b4e788986ea5cc518e8",
-                "sha256:75c413551a436b462d5929255b6dc9c0c3c2b25cbeaee5271a56c7fda8ca49c0",
-                "sha256:769b740aeebd584cd59232be84fdcaf6270b8adc356596cdea5b2152c82caaac",
-                "sha256:ad2383d39f13534f3ca5c48fe1fc0975676846dc39c2cece78c0f1f9891418e0",
-                "sha256:b417bb7ff680d43e7bd7a13e2e08956fa6acb11fd432f74c97b7664f8bdb6ec1",
-                "sha256:b6ef0cabaf5a6ecb5ac122e689d25ba12433a90c7b067b12e5f28bdb7fb78254",
-                "sha256:c2de19c88bdb0366c976cc125dca1002ec1b346989d59524178adfd395e62421",
-                "sha256:c7b04a6dc74087b1598de8d713198de4718fa30ec6cbb84959b26426c198e041",
-                "sha256:f8f2a0ae8de0b49c7b5b2daca4f150fdd9c1173e854df2cce3b04123244f9f45",
-                "sha256:fcfadaf4bf68a27e5dc2f42cbb2f4b4ceea9f05d1d0b8f7787e640bed2801634"
+                "sha256:0411b5bf0de5ec11060925fd811ad49073fa19f995bcf408839eb619b59bb9f7",
+                "sha256:131f4ed14f0fd28d2a9fa50f79a57d5ed1c8f742d3ccac3d773fee09ef6fe217",
+                "sha256:13510d32f8db72a0b3e1720dbf8cba5c4eecdf07abc4cb631982f51256c453d1",
+                "sha256:31dc4d77ef04ab0460d024786f51466dbbc274fda7c8aad0885a6df5ff8d642e",
+                "sha256:35021d9fecea53b21e4defec0ff3ad69a8e2b75aca1ceddd444a5ba71216547e",
+                "sha256:426a8ef9e3b97c27e841648241c2862442c13c91ec4a48c4a72b262ccf30add9",
+                "sha256:58217698193fb94f3e6ff57eed0ae20381a8d06c2bc10151f76c06bb449a3a19",
+                "sha256:5f45adbbb69281845981bb4e0a4efb8a405f10f3cd6c349cb4a5db3357c6bf93",
+                "sha256:5fdb524767288f7ad161d2182f7ed6cafc0a283363728dcd04b9485f6411547c",
+                "sha256:71fbee1f7ef3fb42efa3761a8faefc796e7e425f528de536cfb4c9de03bde885",
+                "sha256:80bd314157851d06f7db7ca527082dbb0ee97afefb529cdcd59f7a5950927ba0",
+                "sha256:b843c9ef6aed54a2649887f55959da0031595ccfaf7e7a0ba7aa681ffeaa0aa1",
+                "sha256:c6a05ef8125503d2d282ccf1448e3599b8a6bd805c3cdee79760fa3da0ea090e",
+                "sha256:deeda2769a52db840efe5bf7bdf7cefa0ae17b43a844a3259d39fb9465c8b008",
+                "sha256:e66f8b09eec1afdcab947d3a1d65b87b25fde39e9172ae1bec562488335633b4",
+                "sha256:e8db93045414980dbada8908d49dbbc0aa134277da3ff613b3e548cb275bdd37",
+                "sha256:f1cc268a15ade58d9a0c04569fe6613e19b8b0345b64453064e2c3c6d79051af",
+                "sha256:fe3001b6a4f3f3582a865b9e5081cc548b973ec20320f297f5e2d46860e9c703",
+                "sha256:fe85bf7adb26eb47ad53a1bae5d35a28df16b2b93b89042a3a28746617a4738d"
             ],
-            "markers": "platform_python_implementation == 'CPython'",
-            "version": "==0.4.13"
+            "markers": "platform_python_implementation == 'cpython'",
+            "version": "==0.4.14"
         },
         "gunicorn": {
             "hashes": [
@@ -140,6 +157,12 @@
             ],
             "index": "pypi",
             "version": "==19.8.1"
+        },
+        "httpcache": {
+            "hashes": [
+                "sha256:32c2b811129e4f54d6ec4beb2b260e047f1ec7bf9dfb6494cbc2cbc43bb174a5"
+            ],
+            "version": "==0.1.3"
         },
         "idna": {
             "hashes": [
@@ -188,6 +211,13 @@
             ],
             "version": "==1.0"
         },
+        "ply": {
+            "hashes": [
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+            ],
+            "version": "==3.11"
+        },
         "psycopg2": {
             "hashes": [
                 "sha256:0147e990cef0332e239de711f165b2a5e6feb7c5f8583985d4a3dcac1680a782",
@@ -225,6 +255,12 @@
             "index": "pypi",
             "version": "==2.7.1"
         },
+        "py-zipkin": {
+            "hashes": [
+                "sha256:1cbf48c8b7e5a30c36e8eb97560b81813c38af0bdb6ad901b23bdbced15a9b79"
+            ],
+            "version": "==0.13.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:3acbef017340600e9ff8f2994d8f7afd6eacb295383f286466a6df3961e486f0",
@@ -240,6 +276,13 @@
             ],
             "version": "==1.0.3"
         },
+        "reppy": {
+            "hashes": [
+                "sha256:2ad4c1ce8c1b73af4f132e1427e39072705a95d3151b7e0efbf1932bce03e3e5",
+                "sha256:80acb6e8b0f386ef8e93489dbedabc8cc38053d4771145e6759d4c140e8c93cd"
+            ],
+            "version": "==0.4.10"
+        },
         "requests": {
             "hashes": [
                 "sha256:8d29f97ed1541709b57caddb77bb20592411d7ca10ec4f03275f49ee8456e225",
@@ -247,6 +290,14 @@
             ],
             "index": "pypi",
             "version": "==2.17.3"
+        },
+        "requests-middleware": {
+            "hashes": [
+                "sha256:97b888d2feccaab3359c74ef884b15c4494b57798e4f73cd541eb67cf1061094",
+                "sha256:ced0d7af9b41888c41cf3e282a56c280c9912e0ed019571122f98a78380c4c6c"
+            ],
+            "index": "pypi",
+            "version": "==0.1.2"
         },
         "retrying": {
             "hashes": [
@@ -284,6 +335,12 @@
             "index": "pypi",
             "version": "==17.2.0"
         },
+        "thriftpy": {
+            "hashes": [
+                "sha256:309e57d97b5bfa01601393ad4f245451e989d6206a59279e56866b264a99796d"
+            ],
+            "version": "==0.3.9"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1",
@@ -302,10 +359,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
-                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
+                "sha256:292fa429e69d60e4161e7612cb7cc8fa3609e2e309f80c224d93a76d5e7b58be",
+                "sha256:c7013d119ec95eb626f7a2011f0b63d0c9a095df9ad06d8507b37084eada1a8d"
             ],
-            "version": "==1.6.5"
+            "version": "==2.0.4"
         },
         "atomicwrites": {
             "hashes": [
@@ -333,10 +390,13 @@
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
                 "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
                 "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
                 "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
                 "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
                 "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
                 "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
@@ -464,26 +524,25 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
-                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
-                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
+                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "version": "==0.6.0"
+            "version": "==0.7.1"
         },
         "py": {
             "hashes": [
-                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
-                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "version": "==1.5.3"
+            "version": "==1.5.4"
         },
         "pycodestyle": {
             "hashes": [
@@ -501,18 +560,18 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:a48070545c12430cfc4e865bf62f5ad367784765681b3db442d8230f0960aa3c",
-                "sha256:fff220bcb996b4f7e2b0f6812fd81507b72ca4d8c4d05daf2655c333800cb9b3"
+                "sha256:1d6d3622c94b4887115fe5204982eee66fdd8a951cf98635ee5caee6ec98c3ec",
+                "sha256:31142f764d2a7cd41df5196f9933b12b7ee55e73ef12204b648ad7e556c119fb"
             ],
             "index": "pypi",
-            "version": "==1.9.2"
+            "version": "==2.1.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c",
-                "sha256:90898786b3d0b880b47645bae7b51aa9bbf1e9d1e4510c2cfd15dd65c70ea0cd"
+                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02",
+                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118"
             ],
-            "version": "==3.6.2"
+            "version": "==3.7.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -531,11 +590,40 @@
         },
         "tox": {
             "hashes": [
-                "sha256:96efa09710a3daeeb845561ebbe1497641d9cef2ee0aea30db6969058b2bda2f",
-                "sha256:9ee7de958a43806402a38c0d2aa07fa8553f4d2c20a15b140e9f771c2afeade0"
+                "sha256:37cf240781b662fb790710c6998527e65ca6851eace84d1595ee71f7af4e85f7",
+                "sha256:eb61aa5bcce65325538686f09848f04ef679b5cd9b83cc491272099b28739600"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==3.2.1"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
+                "sha256:10703d3cec8dcd9eef5a630a04056bbc898abc19bac5691612acba7d1325b66d",
+                "sha256:1f6c4bd0bdc0f14246fd41262df7dfc018d65bb05f6e16390b7ea26ca454a291",
+                "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
+                "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
+                "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
+                "sha256:3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9",
+                "sha256:519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded",
+                "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",
+                "sha256:668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe",
+                "sha256:68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd",
+                "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
+                "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
+                "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
+                "sha256:898f818399cafcdb93cbbe15fc83a33d05f18e29fb498ddc09b0214cdfc7cd51",
+                "sha256:94b091dc0f19291adcb279a108f5d38de2430411068b219f41b343c03b28fb1f",
+                "sha256:a26863198902cda15ab4503991e8cf1ca874219e0118cbf07c126bce7c4db129",
+                "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
+                "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
+                "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",
+                "sha256:c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559",
+                "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
+                "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
+            ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
+            "version": "==1.1.0"
         },
         "virtualenv": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -1,10 +1,12 @@
-from json import loads
 import logging
+from json import loads
 
 import structlog
+from flask_zipkin import Zipkin
 from retrying import RetryError
 
 from logger_config import logger_initial_config
+from ras_party import clients
 from run import create_app, initialise_db
 
 """
@@ -14,6 +16,11 @@ This is a duplicate of run.py, with minor modifications to support gunicorn exec
 logger = structlog.wrap_logger(logging.getLogger(__name__))
 
 app = create_app()
+
+# Zipkin
+zipkin = Zipkin(app=app, sample_rate=app.config.get("ZIPKIN_SAMPLE_RATE"))
+clients.zipkin = zipkin
+
 with open(app.config['PARTY_SCHEMA']) as io:
     app.config['PARTY_SCHEMA'] = loads(io.read())
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 import os
+from distutils.util import strtobool
 
 from ras_party.cloud.cloudfoundry import ONSCloudFoundry
 
@@ -38,6 +39,11 @@ class Config(object):
     else:
         DATABASE_SCHEMA = os.getenv('DATABASE_SCHEMA', 'partysvc')
         DATABASE_URI = os.getenv('DATABASE_URI', "postgres://postgres:postgres@localhost:6432/postgres")
+
+    # Zipkin
+    ZIPKIN_DISABLE = bool(strtobool(os.getenv("ZIPKIN_DISABLE", "False")))
+    ZIPKIN_DSN = os.getenv("ZIPKIN_DSN", None)
+    ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", 0))
 
     REQUESTS_GET_TIMEOUT = os.getenv('REQUESTS_GET_TIMEOUT', 20)
     REQUESTS_POST_TIMEOUT = os.getenv('REQUESTS_POST_TIMEOUT', 20)

--- a/ras_party/clients/__init__.py
+++ b/ras_party/clients/__init__.py
@@ -1,0 +1,50 @@
+import requests
+from flask import current_app
+from flask_zipkin import Zipkin
+from requests.auth import HTTPBasicAuth
+from requests_middleware import BaseMiddleware, MiddlewareHTTPAdapter
+
+zipkin: Zipkin = None
+
+
+def http():
+    config = current_app.config
+
+    session = requests.Session()
+    session.auth = HTTPBasicAuth(config['SECURITY_USER_NAME'], config['SECURITY_USER_PASSWORD'])
+
+    middleware = [
+        ZipkinMiddleware(zipkin),
+    ]
+
+    adapter = TimeoutMiddlewareHTTPAdapter(
+        middlewares=middleware,
+        timeout=int(current_app.config['REQUESTS_POST_TIMEOUT'])
+    )
+
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+
+    return session
+
+
+class ZipkinMiddleware(BaseMiddleware):
+    client: Zipkin
+
+    def __init__(self, client):
+        self.client = client
+
+    def before_send(self, request, *args, **kwargs):
+        request.headers = self.client.create_http_headers_for_new_span().update(request.headers)
+
+
+class TimeoutMiddlewareHTTPAdapter(MiddlewareHTTPAdapter):
+    def __init__(self, timeout=None, *args, **kwargs):
+        self.timeout = timeout
+        super(MiddlewareHTTPAdapter, self).__init__(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = self.timeout
+
+        return super(MiddlewareHTTPAdapter, self).send(*args, **kwargs)

--- a/ras_party/clients/oauth_client.py
+++ b/ras_party/clients/oauth_client.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-from ras_party.support.requests_wrapper import Requests
+from ras_party.clients import http
 
 
 class OauthClient:
@@ -21,7 +21,7 @@ class OauthClient:
             'client_secret': self.client_secret
         }
         basic_auth = (self.client_id, self.client_secret)
-        return Requests.post(self.admin_url, auth=basic_auth, data=payload)
+        return http().post(self.admin_url, auth=basic_auth, data=payload)
 
     def update_account(self, **kwargs):
         basic_auth = (self.client_id, self.client_secret)
@@ -30,4 +30,4 @@ class OauthClient:
             'client_secret': self.client_secret
         }
         payload.update(kwargs)
-        return Requests.put(self.admin_url, auth=basic_auth, data=payload)
+        return http().put(self.admin_url, auth=basic_auth, data=payload)

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -6,6 +6,7 @@ from itsdangerous import SignatureExpired, BadSignature, BadData
 from sqlalchemy import orm
 import structlog
 
+from ras_party.clients import http
 from ras_party.clients.oauth_client import OauthClient
 from ras_party.controllers.notify_gateway import NotifyGateway
 from ras_party.controllers.queries import query_respondent_by_email, query_respondent_by_pending_email
@@ -18,7 +19,6 @@ from ras_party.exceptions import ClientError, RasError, RasNotifyError
 from ras_party.models.models import BusinessRespondent, Enrolment, EnrolmentStatus
 from ras_party.models.models import PendingEnrolment, Respondent, RespondentStatus
 from ras_party.support.public_website import PublicWebsite
-from ras_party.support.requests_wrapper import Requests
 from ras_party.support.session_decorator import with_db_session
 from ras_party.support.transactional import transactional
 from ras_party.support.verification import decode_email_token
@@ -570,7 +570,7 @@ def request_iac(enrolment_code):
     iac_svc = current_app.config['RAS_IAC_SERVICE']
     iac_url = f'{iac_svc}/iacs/{enrolment_code}'
     logger.info('GET URL', url=iac_url)
-    response = Requests.get(iac_url)
+    response = http().get(iac_url)
     logger.info('IAC service responded with', code=response.status_code)
     response.raise_for_status()
     return response.json()
@@ -580,7 +580,7 @@ def request_case(enrolment_code):
     case_svc = current_app.config['RAS_CASE_SERVICE']
     case_url = f'{case_svc}/cases/iac/{enrolment_code}'
     logger.info('GET URL', url=case_url)
-    response = Requests.get(case_url)
+    response = http().get(case_url)
     logger.info('Case service responded with', status=response.status_code)
     response.raise_for_status()
     return response.json()
@@ -590,7 +590,7 @@ def request_collection_exercise(collection_exercise_id):
     ce_svc = current_app.config['RAS_COLLEX_SERVICE']
     ce_url = f'{ce_svc}/collectionexercises/{collection_exercise_id}'
     logger.info('GET', url=ce_url)
-    response = Requests.get(ce_url)
+    response = http().get(ce_url)
     logger.info('Collection exercise service responded with', status=response.status_code)
     response.raise_for_status()
     return response.json()
@@ -600,7 +600,7 @@ def request_survey(survey_id):
     survey_svc = current_app.config['RAS_SURVEY_SERVICE']
     survey_url = f'{survey_svc}/surveys/{survey_id}'
     logger.info('GET', url=survey_url)
-    response = Requests.get(survey_url)
+    response = http().get(survey_url)
     logger.info('Survey service responded with', status=response.status_code)
     response.raise_for_status()
     return response.json()
@@ -617,7 +617,7 @@ def post_case_event(case_id, party_id, category='Default category message', desc
         'createdBy': 'Party Service'
     }
 
-    response = Requests.post(case_url, json=payload)
+    response = http().post(case_url, json=payload)
     response.raise_for_status()
     logger.debug('Successfully posted case event')
     return response.json()
@@ -626,7 +626,7 @@ def post_case_event(case_id, party_id, category='Default category message', desc
 def request_cases_for_respondent(respondent_id):
     logger.debug('Retrieving cases for respondent', respondent_id=respondent_id)
     url = f'{current_app.config["RAS_CASE_SERVICE"]}/cases/partyid/{respondent_id}'
-    response = Requests.get(url)
+    response = http().get(url)
     response.raise_for_status()
     logger.debug('Successfully retrieved cases for respondent', respondent_id=respondent_id)
     return response.json()
@@ -635,7 +635,7 @@ def request_cases_for_respondent(respondent_id):
 def request_casegroups_for_business(business_id):
     logger.debug('Retrieving casegroups for business', business_id=business_id)
     url = f'{current_app.config["RAS_CASE_SERVICE"]}/casegroups/partyid/{business_id}'
-    response = Requests.get(url)
+    response = http().get(url)
     response.raise_for_status()
     logger.debug('Successfully retrieved casegroups for business', business_id=business_id)
     return response.json()
@@ -644,7 +644,7 @@ def request_casegroups_for_business(business_id):
 def request_collection_exercises_for_survey(survey_id):
     logger.debug('Retrieving collection exercises for survey', survey_id=survey_id)
     url = f'{current_app.config["RAS_COLLEX_SERVICE"]}/collectionexercises/survey/{survey_id}'
-    response = Requests.get(url)
+    response = http().get(url)
     response.raise_for_status()
     logger.debug('Successfully retrieved collection exercises for survey', survey_id=survey_id)
     return response.json()

--- a/ras_party/controllers/notify_gateway.py
+++ b/ras_party/controllers/notify_gateway.py
@@ -2,8 +2,8 @@ import logging
 
 import structlog
 
+from ras_party.clients import http
 from ras_party.exceptions import RasNotifyError
-from ras_party.support.requests_wrapper import Requests
 from urllib import parse as urlparse
 
 logger = structlog.wrap_logger(logging.getLogger(__name__))
@@ -44,7 +44,7 @@ class NotifyGateway:
 
             url = urlparse.urljoin(self.notify_url, str(template_id))
 
-            response = Requests.post(url, json=notification)
+            response = http().post(url, json=notification)
 
             logger.info('Notification id sent via Notify-Gateway to GOV.UK Notify.', id=response.json()["id"])
 

--- a/run.py
+++ b/run.py
@@ -2,7 +2,6 @@ import os
 import logging
 from json import loads
 
-
 import structlog
 from alembic.config import Config
 from alembic import command

--- a/test/test_businesses_search.py
+++ b/test/test_businesses_search.py
@@ -1,5 +1,4 @@
-from ras_party.support.requests_wrapper import Requests
-
+from ras_party import clients
 from test.mocks import MockRequests
 from test.party_client import PartyTestClient
 from test.test_data.mock_business import MockBusiness
@@ -8,8 +7,7 @@ from test.test_data.mock_business import MockBusiness
 class TestBusinessesSearch(PartyTestClient):
 
     def setUp(self):
-        self.mock_requests = MockRequests()
-        Requests._lib = self.mock_requests
+        clients.http = MockRequests()
 
     def _make_business_attributes_active(self, mock_business):
         sample_id = mock_business['sampleSummaryId']

--- a/test/test_notify_gateway.py
+++ b/test/test_notify_gateway.py
@@ -1,21 +1,20 @@
 from flask import current_app
 
+from ras_party import clients
 from ras_party.controllers.notify_gateway import NotifyGateway
 from ras_party.exceptions import RasNotifyError
 from test.party_client import PartyTestClient
 from test.mocks import MockRequests
-from ras_party.support.requests_wrapper import Requests
 
 
 class TestNotifyGateway(PartyTestClient):
     """ Notify gateway test class"""
     def setUp(self):
-        self.mock_requests = MockRequests()
-        Requests._lib = self.mock_requests
+        clients.http = MockRequests()
 
     def test_notify_sends_notification_with_basic_message(self):
         # Given a mocked notify gateway and response
-        self.mock_requests.post.response_payload = '{"id": "notification id"}'
+        clients.http.post.response_payload = '{"id": "notification id"}'
 
         notify = NotifyGateway(current_app.config)
         # When an email is sent
@@ -28,13 +27,13 @@ class TestNotifyGateway(PartyTestClient):
                                      current_app.config['SECURITY_USER_PASSWORD']),
                             "timeout": 99, "json": expected_data}
 
-        self.mock_requests.post.assert_called_with(
+        clients.http.post.assert_called_with(
             "http://notifygatewaysvc-dev.apps.devtest.onsclofo.uk/emails/email_verification_id",
             expected_request)
 
     def test_notify_sends_notification_with_extended_message(self):
         # Given a mocked notify gateway and response
-        self.mock_requests.post.response_payload = '{"id": "notification id"}'
+        clients.http.post.response_payload = '{"id": "notification id"}'
 
         notify = NotifyGateway(current_app.config)
         # When an email is sent
@@ -45,7 +44,7 @@ class TestNotifyGateway(PartyTestClient):
                                      current_app.config['SECURITY_USER_PASSWORD']),
                             "timeout": 99, "json": expected_data}
 
-        self.mock_requests.post.assert_called_with(
+        clients.http.post.assert_called_with(
             "http://notifygatewaysvc-dev.apps.devtest.onsclofo.uk/emails/request_password_change_id",
             expected_request)
 
@@ -53,7 +52,7 @@ class TestNotifyGateway(PartyTestClient):
         # Given a mocked gov.uk notify and exception
         def mock_post_notify(*args, **kwargs):
             return Exception
-        self.mock_requests.post = mock_post_notify
+        clients.http.post = mock_post_notify
 
         # When an email is sent
         notify = NotifyGateway(current_app.config)

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -1,6 +1,6 @@
 import uuid
 
-from ras_party.support.requests_wrapper import Requests
+from ras_party import clients
 
 from test.mocks import MockRequests
 from test.party_client import PartyTestClient, businesses
@@ -10,8 +10,7 @@ from test.test_data.mock_business import MockBusiness
 class TestParties(PartyTestClient):
 
     def setUp(self):
-        self.mock_requests = MockRequests()
-        Requests._lib = self.mock_requests
+        clients.http = MockRequests()
 
     def _make_business_attributes_active(self, mock_business):
         sample_id = mock_business['sampleSummaryId']

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 from flask import current_app
 from itsdangerous import URLSafeTimedSerializer
 
+from ras_party import clients
 from ras_party.controllers import account_controller
 from ras_party.controllers.queries import query_respondent_by_party_uuid, query_business_by_party_uuid
 from ras_party.exceptions import ClientError
 from ras_party.models.models import BusinessRespondent, Enrolment, RespondentStatus, Respondent
 from ras_party.support.public_website import PublicWebsite
-from ras_party.support.requests_wrapper import Requests
 from ras_party.support.session_decorator import with_db_session
 from ras_party.support.transactional import transactional
 from ras_party.support.verification import generate_email_token
@@ -25,8 +25,7 @@ from test.test_data.mock_respondent import MockRespondent, MockRespondentWithId,
 class TestRespondents(PartyTestClient):
 
     def setUp(self):
-        self.mock_requests = MockRequests()
-        Requests._lib = self.mock_requests
+        clients.http = MockRequests()
         self.mock_notify = MagicMock()
         account_controller.NotifyGateway = MagicMock(return_value=self.mock_notify)
         self.mock_respondent = MockRespondent().attributes().as_respondent()


### PR DESCRIPTION
This is an alternative approach for the python services done as a spike to see if there was a better implementation integrating the zipkin tracing. This is a better structured bit of code than patching requests. However it's pretty high impact in what it requires changing.

Motivation and Context
==

Currently there's no way to trace the requests through the application.

What Changed
==

This will add the tracing headers to any request that comes through this
application onto another service, or preserve existing headers allowing
the user to follow requests through the application as a whole.

There are also new configuration settings:

```
| ZIPKIN_DISABLE                  | Totally disable Zipkin (including tracing headers)            | False
| ZIPKIN_DSN                      | Zipkin Sample API URL (e.g. http://zipkin:9411/api/v1/spans)  | None
| ZIPKIN_SAMPLE_RATE              | Percentage of requests to send to zipkin span API             | 0
```

By default this will add the tracing headers, but make no requests to
Zipkin's neat little UI.

How to test
==

No visible functional changes, check to see if downstream services are
receiving the headers:

* 'X-B3-TraceId'
* 'X-B3-SpanId'
* 'X-B3-ParentSpanId'
* 'X-B3-Flags'
* 'X-B3-Sampled'

You can also set the environment variables

To see the spans go to zipkin:

* Set the environment variable `ZIPKIN_DSN` to a locally running zipkin
  server
* Set the environment variable `ZIPKIN_SAMPLE_RATE` to 100

Then run the acceptance tests.

Links
==
* [Add Call time metrics into Splunk for Python Services (3d)][tkt]
* https://github.com/ONSdigital/ras-collection-instrument/pull/126
* https://github.com/ONSdigital/ras-party/pull/151
* https://github.com/ONSdigital/ras-secure-message/pull/227
* https://github.com/ONSdigital/response-operations-ui/pull/219
* https://github.com/ONSdigital/ras-frontstage/pull/383
* https://github.com/ONSdigital/rm-collection-exercise-service/pull/114
* https://github.com/ONSdigital/rm-case-service/pull/71
* https://github.com/ONSdigital/rm-actionexporter-service/pull/46
* https://github.com/ONSdigital/iac-service/pull/20
* https://github.com/ONSdigital/rm-sample-service/pull/74
* https://github.com/ONSdigital/rm-notify-gateway/pull/44
* https://github.com/ONSdigital/rm-sdx-gateway/pull/20
* https://github.com/ONSdigital/ras-party/pull/155
* https://github.com/ONSdigital/ras-rm-docker-dev/pull/80

[tkt]: https://trello.com/c/eY86bZG9/83-add-call-time-metrics-into-splunk-for-python-services-3d