### PR TITLE
Undo pipenv update

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -273,11 +273,10 @@
         },
         "requestsdefaulter": {
             "hashes": [
-                "sha256:5e185d9b38f29215c78446188afd70765a8e876244eec6a5f0e71ae437fdb128",
-                "sha256:bb83e7f96009be470d1dea55c270c9dad06fb231dd33dda483ab3d8ffb6b8102"
+                "sha256:5682733d391af907d8e5e95a5470b3b785275f1089a7a7113f1bb288b9d4631a"
             ],
             "index": "pypi",
-            "version": "==0.1.0"
+            "version": "==0.1.1"
         },
         "retrying": {
             "hashes": [


### PR DESCRIPTION
Currently party is broken. This looks like it's related to greenlets.
This should resolve that.


<!--- Why is this change required? What problem does it solve? -->

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->