### PR TITLE
Log Zipkin IDs.

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,10 +2,7 @@ import logging
 from json import loads
 
 import structlog
-import requestsdefaulter
-
 from retrying import RetryError
-from flask_zipkin import Zipkin
 
 from logger_config import logger_initial_config
 from run import create_app, initialise_db
@@ -18,10 +15,6 @@ This is a duplicate of run.py, with minor modifications to support gunicorn exec
 logger = structlog.wrap_logger(logging.getLogger(__name__))
 
 app = create_app()
-
-# Zipkin
-zipkin = Zipkin(app=app, sample_rate=app.config.get("ZIPKIN_SAMPLE_RATE"))
-requestsdefaulter.default_headers(zipkin.create_http_headers_for_new_span)
 
 with open(app.config['PARTY_SCHEMA']) as io:
     app.config['PARTY_SCHEMA'] = loads(io.read())

--- a/logger_config.py
+++ b/logger_config.py
@@ -1,10 +1,12 @@
 import logging
 import os
 import sys
+import flask
 
 from structlog import configure
 from structlog.processors import JSONRenderer, TimeStamper
 from structlog.stdlib import add_log_level, filter_by_level
+from flask import g
 
 
 def logger_initial_config(service_name=None,
@@ -34,6 +36,20 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
+    def zipkin_ids(logger, method_name, event_dict):
+        event_dict['zipkin_trace_id'] = ''
+        event_dict['zipkin_span_id'] = ''
+        if not flask.has_app_context():
+            return event_dict
+
+        if '_zipkin_span' not in g:
+            return event_dict
+
+        event_dict['zipkin_span_id'] = g._zipkin_span.zipkin_attrs.span_id
+        event_dict['zipkin_trace_id'] = g._zipkin_span.zipkin_attrs.trace_id
+
+        return event_dict
+
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
-    configure(processors=[add_log_level, filter_by_level, add_service,
+    configure(processors=[zipkin_ids, add_log_level, filter_by_level, add_service,
                           TimeStamper(fmt=logger_date_format, utc=True, key="created_at"), JSONRenderer(indent=indent)])


### PR DESCRIPTION
# Motivation and Context
Currently there's no way to trace the requests through the application.

# What has changed
This will add the trace and span IDs into all log statements.

# How to test?
Run unit and acceptance tests.

# Links
https://trello.com/c/5cYDTILb/156-add-the-zipkin-correlation-and-span-id-into-the-logs-for-python-services-2d
