### PR TITLE
Added account controller to unlock account from party service

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -333,6 +333,14 @@ def change_respondent_account_status(payload, party_id, session):
     if not respondent:
         raise ClientError("Respondent does not exist", respondent_id=party_id,
                           status=404)
+    # Unlock respondents account
+    if status == 'ACTIVE':
+        email_address = respondent.email_address
+        oauth_response = OauthClient().update_account(username=email_address, account_locked='False')
+
+        if oauth_response.status_code != 201:
+            raise RasError('Failed to unlock respondent account', respondent_id=str(respondent.party_uuid))
+
     respondent.status = status
 
 

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -4,6 +4,7 @@ import uuid
 import structlog
 from flask import current_app
 from itsdangerous import SignatureExpired, BadSignature, BadData
+from requests import HTTPError
 from sqlalchemy import orm
 
 from ras_party.clients.oauth_client import OauthClient
@@ -329,15 +330,20 @@ def change_respondent_account_status(payload, party_id, session):
 
     respondent = query_respondent_by_party_uuid(party_id, session)
     if not respondent:
-        raise ClientError("Respondent does not exist", respondent_id=party_id,
+        raise ClientError('Respondent does not exist', respondent_id=party_id,
                           status=404)
+
     # Unlock respondents account
     if status == 'ACTIVE':
         email_address = respondent.email_address
         oauth_response = OauthClient().update_account(username=email_address, account_locked='False')
 
-        if oauth_response.status_code != 201:
+        try:
+            oauth_response.raise_for_status()
+        except HTTPError:
             raise RasError('Failed to unlock respondent account', respondent_id=str(respondent.party_uuid))
+
+        logger.debug('Respondent account updated', respondent_id=party_id)
 
     respondent.status = status
 

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -949,3 +949,15 @@ class TestRespondents(PartyTestClient):
             'status_change': 'ACTIVE'
         }
         self.put_respondent_account_status(request_json, party_id, 404)
+
+    def test_put_change_respondent_account_status_bad_oauth2_response(self):
+        self.populate_with_respondent(respondent=self.mock_respondent_with_id_suspended)
+        db_respondent = respondents()[0]
+        token = self.generate_valid_token_from_email(db_respondent.email_address)
+        self.put_email_verification(token, 200)
+        party_id = self.mock_respondent_with_id_suspended['id']
+        request_json = {
+            'status_change': 'ACTIVE'
+        }
+        with patch('ras_party.clients.oauth_client.OauthClient.update_account', return_value=401):
+            self.put_respondent_account_status(request_json, party_id, 500)


### PR DESCRIPTION
# Motivation and Context
We want party to call out to django service, when an internal user unlocks an account in ROps. 

# What has changed
Simple functionality added in to existing method to just call out. 

# How to test?
Needs to be run with rest of the changes found on this ticket:
https://trello.com/c/mm4SZ3N5/268-us203-int-ability-to-unlock-a-respondents-account-l

