### PR TITLE
Fix to ensure survey_name is removed from db

### DIFF
--- a/migrations/versions/613bf3a40948_remove_survey_name.py
+++ b/migrations/versions/613bf3a40948_remove_survey_name.py
@@ -5,6 +5,7 @@ Revises: ac604d2cf763
 Create Date: 2018-08-20 10:16:35.995473
 
 """
+import sqlalchemy as sa
 from alembic import op
 
 
@@ -16,8 +17,12 @@ depends_on = None
 
 
 def upgrade():
-    pass
+    op.drop_column('survey_name', schema='partysvc.enrolment')
 
 
 def downgrade():
-    op.drop_column('survey_name', schema='partysvc.enrolment')
+    op.add_column(
+        'survey_name',
+        sa.Column('survey_name', sa.Text, nullable=True),
+        schema='partysvc.enrolment'
+    )


### PR DESCRIPTION
### Context
Fix for: https://github.com/ONSdigital/rm-collection-exercise-service/pull/113

### How to Test
Actually check its been removed from the db i.e. survey_name column