### PR TITLE
269 ext user account unlock

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
                 RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE = credentials('RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE')
                 RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE = credentials('RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE')
                 RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE = credentials('RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE')
+                RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE = credentials('RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE')
             }
             steps {
                 sh "cf login -a https://${env.CLOUDFOUNDRY_API} --skip-ssl-validation -u ${CF_USER_USR} -p ${CF_USER_PSW} -o rmras -s dev"
@@ -45,6 +46,7 @@ pipeline {
                 sh "cf set-env ras-party-dev RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE ${env.RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE}"
                 sh "cf set-env ras-party-dev RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE ${env.RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE}"
                 sh "cf set-env ras-party-dev RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE ${env.RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE}"
+                sh "cf set-env ras-party-dev RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE ${env.RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE}"
 
                 sh "cf set-env ras-party-dev RAS_IAC_SERVICE_HOST iacsvc-dev.${env.CF_DOMAIN}"
                 sh "cf set-env ras-party-dev RAS_IAC_SERVICE_PORT 80"
@@ -94,6 +96,7 @@ pipeline {
                 RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE = credentials('RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE')
                 RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE = credentials('RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE')
                 RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE = credentials('RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE')
+                RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE = credentials('RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE')
             }
             steps {
                 sh "cf login -a https://${env.CLOUDFOUNDRY_API} --skip-ssl-validation -u ${CF_USER_USR} -p ${CF_USER_PSW} -o rmras -s ci"
@@ -115,6 +118,8 @@ pipeline {
                 sh "cf set-env ras-party-ci RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE ${env.RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE}"
                 sh "cf set-env ras-party-ci RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE ${env.RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE}"
                 sh "cf set-env ras-party-ci RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE ${env.RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE}"
+                sh "cf set-env ras-party-ci RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE ${env.RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE}"
+
 
                 sh "cf set-env ras-party-ci RAS_IAC_SERVICE_HOST iacsvc-ci.${env.CF_DOMAIN}"
                 sh "cf set-env ras-party-ci RAS_IAC_SERVICE_PORT 80"
@@ -186,6 +191,7 @@ pipeline {
                 RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE = credentials('RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE')
                 RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE = credentials('RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE')
                 RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE = credentials('RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE')
+                RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE = credentials('RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE')
             }
             steps {
                 sh "cf login -a https://${env.CLOUDFOUNDRY_API} --skip-ssl-validation -u ${CF_USER_USR} -p ${CF_USER_PSW} -o rmras -s test"
@@ -207,6 +213,7 @@ pipeline {
                 sh "cf set-env ras-party-test RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE ${env.RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE}"
                 sh "cf set-env ras-party-test RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE ${env.RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE}"
                 sh "cf set-env ras-party-test RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE ${env.RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE}"
+                sh "cf set-env ras-party-test RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE ${env.RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE}"
 
                 sh "cf set-env ras-party-test RAS_IAC_SERVICE_HOST iacsvc-test.${env.CF_DOMAIN}"
                 sh "cf set-env ras-party-test RAS_IAC_SERVICE_PORT 80"

--- a/config.py
+++ b/config.py
@@ -75,8 +75,11 @@ class Config(object):
 
     RAS_NOTIFY_SERVICE_URL = os.getenv('RAS_NOTIFY_SERVICE_URL', 'http://notify-gateway-service/emails/')
     RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE = os.getenv('RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE', 'email_verification_id')
-    RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE = os.getenv('RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE', 'request_password_change_id')
-    RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE = os.getenv('RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE', 'confirm_password_change_id')
+    RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE = os.getenv('RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE',
+                                                            'request_password_change_id')
+    RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE = os.getenv('RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE',
+                                                            'confirm_password_change_id')
+    RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE = os.getenv('RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE', 'account_locked_id')
 
     RAS_API_GATEWAY_PROTOCOL = os.getenv('RAS_API_GATEWAY_PROTOCOL', 'http')
     RAS_API_GATEWAY_HOST = os.getenv('RAS_API_GATEWAY_HOST', 'localhost')
@@ -143,6 +146,7 @@ class TestingConfig(DevelopmentConfig):
     RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE = 'email_verification_id'
     RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE = 'request_password_change_id'
     RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE = 'confirm_password_change_id'
+    RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE = 'account_locked_id'
     RAS_IAC_SERVICE = 'http://mockhost:6666'
 
     SEND_EMAIL_TO_GOV_NOTIFY = True

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -526,7 +526,10 @@ def _send_email_verification(party_id, email):
     }
 
     try:
-        NotifyGateway(current_app.config).verify_email(email, personalisation, str(party_id))
+        NotifyGateway(current_app.config).request_to_notify(email=email,
+                                                            template_name='email_verification',
+                                                            personalisation=personalisation,
+                                                            reference=str(party_id))
         logger.info('Verification email sent', party_id=str(party_id))
     except RasNotifyError:
         # Note: intentionally suppresses exception
@@ -723,7 +726,7 @@ def notify_account_lock(payload, session):
 
     try:
         NotifyGateway(current_app.config).request_to_notify(email=email_address,
-                                                            template_name='account_locked',
+                                                            template_name='notify_account_locked',
                                                             personalisation=personalisation,
                                                             reference=party_id)
     except RasNotifyError:

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -239,9 +239,7 @@ def verify_token(token, session):
 @transactional
 @with_db_session
 def change_respondent_password(token, payload, tran, session):
-    v = Validator(Exists('new_password'))
-    if not v.validate(payload):
-        raise ClientError(v.errors, 400)
+    _is_valid(payload, attribute='new_password')
 
     try:
         duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
@@ -296,9 +294,7 @@ def change_respondent_password(token, payload, tran, session):
 
 @with_db_session
 def request_password_change(payload, session):
-    v = Validator(Exists('email_address'))
-    if not v.validate(payload):
-        raise ClientError(v.errors, 400)
+    _is_valid(payload, attribute='email_address')
 
     email_address = payload['email_address']
 
@@ -701,9 +697,7 @@ def get_cases_for_casegroups(casegroup_ids, case_party_id):
 
 @with_db_session
 def notify_account_lock(payload, session):
-    v = Validator(Exists('email_address'))
-    if not v.validate(payload):
-        raise ClientError(v.errors, 400)
+    _is_valid(payload, attribute='email_address')
 
     email_address = payload['email_address']
 
@@ -736,3 +730,10 @@ def notify_account_lock(payload, session):
     logger.debug('Password reset email successfully sent', party_id=party_id)
 
     return {'response': "Ok"}
+
+
+def _is_valid(payload, attribute):
+    v = Validator(Exists(attribute))
+    if v.validate(payload):
+        return True
+    raise ClientError(v.errors, 400)

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -304,7 +304,6 @@ def request_password_change(payload, session):
 
     logger.debug("Requesting password change", party_id=respondent.party_uuid)
 
-    email_address = respondent.email_address
     verification_url = PublicWebsite().reset_password_url(email_address)
 
     personalisation = {

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -281,8 +281,10 @@ def change_respondent_password(token, payload, tran, session):
     party_id = respondent.party_uuid
 
     try:
-        NotifyGateway(current_app.config).confirm_password_change(
-            email_address, personalisation, str(party_id))
+        NotifyGateway(current_app.config).request_to_notify(email=email_address,
+                                                            template_name='confirm_password_change',
+                                                            personalisation=personalisation,
+                                                            reference=party_id)
     except RasNotifyError:
         logger.error('Error sending notification email', respondent_id=str(party_id))
 
@@ -319,8 +321,10 @@ def request_password_change(payload, session):
     logger.info('Reset password url', url=verification_url, party_id=party_id)
 
     try:
-        NotifyGateway(current_app.config).request_password_change(
-            email_address, personalisation, party_id)
+        NotifyGateway(current_app.config).request_to_notify(email=email_address,
+                                                            template_name='request_password_change',
+                                                            personalisation=personalisation,
+                                                            reference=party_id)
     except RasNotifyError:
         # Note: intentionally suppresses exception
         logger.error('Error sending request to Notify Gateway', respondent_id=party_id)
@@ -718,8 +722,10 @@ def notify_account_lock(payload, session):
     logger.info('Reset password url', url=verification_url, party_id=party_id)
 
     try:
-        NotifyGateway(current_app.config).notify_account_locked(
-            email_address, personalisation, party_id)
+        NotifyGateway(current_app.config).request_to_notify(email=email_address,
+                                                            template_name='account_locked',
+                                                            personalisation=personalisation,
+                                                            reference=party_id)
     except RasNotifyError:
         # Note: intentionally suppresses exception
         logger.error('Error sending request to Notify Gateway', respondent_id=party_id)

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -296,13 +296,13 @@ def change_respondent_password(token, payload, tran, session):
 def request_password_change(payload, session):
     _is_valid(payload, attribute='email_address')
 
-    email_address = payload['email_address']
-
-    respondent = query_respondent_by_email(email_address, session)
+    respondent = query_respondent_by_email(payload['email_address'], session)
     if not respondent:
         raise ClientError("Respondent does not exist", status=404)
 
     logger.debug("Requesting password change", party_id=respondent.party_uuid)
+
+    email_address = respondent.email_address
 
     verification_url = PublicWebsite().reset_password_url(email_address)
 

--- a/ras_party/controllers/notify_gateway.py
+++ b/ras_party/controllers/notify_gateway.py
@@ -55,10 +55,10 @@ class NotifyGateway:
                                  error=e)
 
     def request_to_notify(self, email, template_name, personalisation=None, reference=None):
-        template_id = self._get_template(template_name)
+        template_id = self._get_template_id(template_name)
         self._send_message(email, template_id, personalisation, reference)
 
-    def _get_template(self, template_name):
+    def _get_template_id(self, template_name):
         templates = {'notify_account_locked': self.notify_account_locked,
                      'confirm_password_change': self.confirm_password_change_template,
                      'request_password_change': self.request_password_change_template,

--- a/ras_party/controllers/notify_gateway.py
+++ b/ras_party/controllers/notify_gateway.py
@@ -67,19 +67,3 @@ class NotifyGateway:
             return templates[template_name]
         else:
             raise KeyError('Template does not exist')
-
-    # def verify_email(self, email, personalisation=None, reference=None):
-    #     template_id = self.email_verification_template
-    #     self._send_message(email, template_id, personalisation, reference)
-    #
-    # def request_password_change(self, email, personalisation=None, reference=None):
-    #     template_id = self.request_password_change_template
-    #     self._send_message(email, template_id, personalisation, reference)
-    #
-    # def confirm_password_change(self, email, personalisation=None, reference=None):
-    #     template_id = self.confirm_password_change_template
-    #     self._send_message(email, template_id, personalisation, reference)
-    #
-    # def account_locked(self, email, personalisation=None, reference=None):
-    #     template_id = self.notify_account_locked
-    #     self._send_message(email, template_id, personalisation, reference)

--- a/ras_party/controllers/notify_gateway.py
+++ b/ras_party/controllers/notify_gateway.py
@@ -68,18 +68,18 @@ class NotifyGateway:
         else:
             raise KeyError('Template does not exist')
 
-    def verify_email(self, email, personalisation=None, reference=None):
-        template_id = self.email_verification_template
-        self._send_message(email, template_id, personalisation, reference)
-
-    def request_password_change(self, email, personalisation=None, reference=None):
-        template_id = self.request_password_change_template
-        self._send_message(email, template_id, personalisation, reference)
-
-    def confirm_password_change(self, email, personalisation=None, reference=None):
-        template_id = self.confirm_password_change_template
-        self._send_message(email, template_id, personalisation, reference)
-
-    def account_locked(self, email, personalisation=None, reference=None):
-        template_id = self.notify_account_locked
-        self._send_message(email, template_id, personalisation, reference)
+    # def verify_email(self, email, personalisation=None, reference=None):
+    #     template_id = self.email_verification_template
+    #     self._send_message(email, template_id, personalisation, reference)
+    #
+    # def request_password_change(self, email, personalisation=None, reference=None):
+    #     template_id = self.request_password_change_template
+    #     self._send_message(email, template_id, personalisation, reference)
+    #
+    # def confirm_password_change(self, email, personalisation=None, reference=None):
+    #     template_id = self.confirm_password_change_template
+    #     self._send_message(email, template_id, personalisation, reference)
+    #
+    # def account_locked(self, email, personalisation=None, reference=None):
+    #     template_id = self.notify_account_locked
+    #     self._send_message(email, template_id, personalisation, reference)

--- a/ras_party/controllers/notify_gateway.py
+++ b/ras_party/controllers/notify_gateway.py
@@ -19,6 +19,7 @@ class NotifyGateway:
         self.email_verification_template = config['RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE']
         self.request_password_change_template = config['RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE']
         self.confirm_password_change_template = config['RAS_NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE']
+        self.notify_account_locked = config['RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE']
 
     def _send_message(self, email, template_id, personalisation=None, reference=None):
         """
@@ -63,4 +64,8 @@ class NotifyGateway:
 
     def confirm_password_change(self, email, personalisation=None, reference=None):
         template_id = self.confirm_password_change_template
+        self._send_message(email, template_id, personalisation, reference)
+
+    def account_locked(self, email, personalisation=None, reference=None):
+        template_id = self.notify_account_locked
         self._send_message(email, template_id, personalisation, reference)

--- a/ras_party/controllers/notify_gateway.py
+++ b/ras_party/controllers/notify_gateway.py
@@ -54,6 +54,20 @@ class NotifyGateway:
             raise RasNotifyError("There was a problem sending a notification via Notify-Gateway to GOV.UK Notify",
                                  error=e)
 
+    def request_to_notify(self, email, template_name, personalisation=None, reference=None):
+        template_id = self._get_template(template_name)
+        self._send_message(email, template_id, personalisation, reference)
+
+    def _get_template(self, template_name):
+        templates = {'notify_account_locked': self.notify_account_locked,
+                     'confirm_password_change': self.confirm_password_change_template,
+                     'request_password_change': self.request_password_change_template,
+                     'email_verification': self.email_verification_template}
+        if template_name in templates:
+            return templates[template_name]
+        else:
+            raise KeyError('Template does not exist')
+
     def verify_email(self, email, personalisation=None, reference=None):
         template_id = self.email_verification_template
         self._send_message(email, template_id, personalisation, reference)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -115,5 +115,5 @@ def change_respondent_enrolment_status():
 @account_view.route('/respondents/notify-respondent', methods=['GET'])
 def send_respondent_account_locked_email():
     payload = request.get_json() or {}
-    response = account_controller.notify_account_lock(payload)
+    response = account_controller.notify_account_lock(payload=payload)
     return make_response(jsonify(response), 200)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -110,3 +110,10 @@ def change_respondent_enrolment_status():
     account_controller.change_respondent_enrolment_status(payload)
 
     return make_response(jsonify('OK'), 200)
+
+
+@account_view.route('/respondents/notify-respondent', methods=['GET'])
+def send_respondent_account_locked_email():
+    payload = request.get_json() or {}
+    response = account_controller.request_password_change(payload)
+    return make_response(jsonify(response), 200)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -90,17 +90,6 @@ def respondent_add_survey():
     return make_response(jsonify('OK'), 200)
 
 
-@account_view.route('/respondents/edit-account-status/<party_id>', methods=['PUT'])
-def put_respondent_account_status(party_id):
-    payload = request.get_json() or {}
-    v = Validator(Exists('status_change'))
-    if not v.validate(payload):
-        raise RasError(v.errors, 400)
-
-    account_controller.change_respondent_account_status(payload, party_id)
-    return make_response(jsonify('OK'), 200)
-
-
 @account_view.route('/respondents/change_enrolment_status', methods=['PUT'])
 def change_respondent_enrolment_status():
     payload = request.get_json() or {}
@@ -112,8 +101,14 @@ def change_respondent_enrolment_status():
     return make_response(jsonify('OK'), 200)
 
 
-@account_view.route('/respondents/notify-respondent', methods=['GET'])
-def send_respondent_account_locked_email():
+@account_view.route('/respondents/edit-account-status/<party_id>', methods=['PUT'])
+def put_edit_account_status(party_id):
+    # This is the party endpoint to lock and notify respondent when account is locked
+    # This is also the end point for internal user to unlock a respondents account
     payload = request.get_json() or {}
-    response = account_controller.notify_account_lock(payload=payload)
+    v = Validator(Exists('status_change'))
+    if not v.validate(payload):
+        raise RasError(v.errors, 400)
+
+    response = account_controller.notify_change_account_status(payload, party_id)
     return make_response(jsonify(response), 200)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -116,5 +116,5 @@ def put_edit_account_status(party_id):
     if not v.validate(payload):
         raise RasError(v.errors, 400)
 
-    response = account_controller.notify_change_account_status(payload, party_id)
+    response = account_controller.notify_change_account_status(payload=payload, party_id=party_id)
     return make_response(jsonify(response), 200)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -115,5 +115,5 @@ def change_respondent_enrolment_status():
 @account_view.route('/respondents/notify-respondent', methods=['GET'])
 def send_respondent_account_locked_email():
     payload = request.get_json() or {}
-    response = account_controller.request_password_change(payload)
+    response = account_controller.notify_account_lock(payload)
     return make_response(jsonify(response), 200)

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -243,3 +243,11 @@ class PartyTestClient(TestCase):
                                    content_type='application/vnd.ons.business+json')
         self.assertStatus(response, expected_status)
         return response.get_data(as_text=True)
+
+    def notify_account_lock(self, payload, expected_status=200):
+        response = self.client.post('/party-api/v1/respondents/notify-respondent',
+                                    data=json.dumps(payload),
+                                    headers=self.auth_headers,
+                                    content_type='application/vnd.ons.business+json')
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -245,9 +245,9 @@ class PartyTestClient(TestCase):
         return response.get_data(as_text=True)
 
     def notify_account_lock(self, payload, expected_status=200):
-        response = self.client.post('/party-api/v1/respondents/notify-respondent',
-                                    data=json.dumps(payload),
-                                    headers=self.auth_headers,
-                                    content_type='application/vnd.ons.business+json')
+        response = self.client.get('/party-api/v1/respondents/notify-respondent',
+                                   data=json.dumps(payload),
+                                   headers=self.auth_headers,
+                                   content_type='application/vnd.ons.business+json')
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -243,11 +243,3 @@ class PartyTestClient(TestCase):
                                    content_type='application/vnd.ons.business+json')
         self.assertStatus(response, expected_status)
         return response.get_data(as_text=True)
-
-    def notify_account_lock(self, payload, expected_status=200):
-        response = self.client.get('/party-api/v1/respondents/notify-respondent',
-                                   data=json.dumps(payload),
-                                   headers=self.auth_headers,
-                                   content_type='application/vnd.ons.business+json')
-        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
-        return json.loads(response.get_data(as_text=True))

--- a/test/test_data/mock_enrolment.py
+++ b/test/test_data/mock_enrolment.py
@@ -32,3 +32,22 @@ class MockEnrolmentDisabled:
 
     def as_enrolment(self):
         return self._attributes
+
+
+class MockEnrolmentPending:
+    def __init__(self):
+        self._attributes = {
+            'business_id': '3b136c4b-7a14-4904-9e01-13364dd7b972',
+            'respondent_id': '1',
+            'survey_id': '02b9c366-7397-42f7-942a-76dc5876d86d',
+            'status': 'PENDING',
+            'created_on': "2017-12-01 13:40:55.495895",
+
+        }
+
+    def attributes(self, **kwargs):
+        self._attributes.update(kwargs)
+        return self
+
+    def as_enrolment(self):
+        return self._attributes

--- a/test/test_notify_gateway.py
+++ b/test/test_notify_gateway.py
@@ -19,7 +19,7 @@ class TestNotifyGateway(PartyTestClient):
 
         notify = NotifyGateway(current_app.config)
         # When an email is sent
-        notify.verify_email('email')
+        notify.request_to_notify('email', 'email_verification')
         # Then send_email_notification is called
 
         expected_data = {"emailAddress": "email"}
@@ -38,7 +38,8 @@ class TestNotifyGateway(PartyTestClient):
 
         notify = NotifyGateway(current_app.config)
         # When an email is sent
-        notify.request_password_change("email", personalisation="personalised message", reference="reference")
+        notify.request_to_notify("email", 'request_password_change', personalisation="personalised message",
+                                 reference="reference")
         # Then send_email_notification is called
         expected_data = {"emailAddress": "email", "personalisation": "personalised message", "reference": "reference"}
         expected_request = {"auth": (current_app.config['SECURITY_USER_NAME'],
@@ -59,4 +60,4 @@ class TestNotifyGateway(PartyTestClient):
         notify = NotifyGateway(current_app.config)
         # Then a RasNotifyError is raised
         with self.assertRaises(RasNotifyError):
-            notify.confirm_password_change('email')
+            notify.request_to_notify('email', 'request_password_change')

--- a/test/test_notify_gateway.py
+++ b/test/test_notify_gateway.py
@@ -61,3 +61,12 @@ class TestNotifyGateway(PartyTestClient):
         # Then a RasNotifyError is raised
         with self.assertRaises(RasNotifyError):
             notify.request_to_notify('email', 'request_password_change')
+
+    def test_get_template_with_fake_template_name(self):
+        # Given a mocked notify gateway
+        notify = NotifyGateway(current_app.config)
+        # When given a fake template name
+        template_name = 'fake_name'
+        # Then a key error is raised
+        with self.assertRaises(KeyError):
+            notify._get_template_id(template_name)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -515,6 +515,18 @@ class TestRespondents(PartyTestClient):
             account_controller.change_respondent_password(token, {'new_password': 'abc'})
             query.assert_called_once_with('test@example.test', db.session())
 
+    @staticmethod
+    def test_change_respondent_password_ras_notify_error():
+        with patch('ras_party.controllers.account_controller.query_respondent_by_email') as query,\
+                patch('ras_party.support.session_decorator.current_app.db') as db,\
+                patch('ras_party.controllers.account_controller.OauthClient') as client,\
+                patch('ras_party.controllers.account_controller.NotifyGateway') as notify:
+            notify.side_effect = RasNotifyError(mock.Mock())
+            token = generate_email_token('test@example.test')
+            client().update_account().status_code = 201
+            account_controller.change_respondent_password(token, {'new_password': 'abc'})
+            query.assert_called_once_with('test@example.test', db.session())
+
     def test_notify_account_lock(self):
         with patch('ras_party.controllers.account_controller.NotifyGateway'), \
              patch('ras_party.controllers.account_controller.PublicWebsite'):

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -358,7 +358,7 @@ class TestRespondents(PartyTestClient):
         # When the request password end point is hit with an existing email address
         payload = {'email_address': respondent.email_address}
         self.request_password_change(payload)
-        self.mock_notify.request_password_change.assert_not_called()
+        self.mock_notify.request_for_notify.assert_not_called()
 
     def test_request_password_change_with_no_email(self):
         payload = {}
@@ -372,7 +372,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent()
         payload = {'email_address': 'not-mock@example.test'}
         self.request_password_change(payload, expected_status=404)
-        self.assertFalse(self.mock_notify.request_password_change.called)
+        self.assertFalse(self.mock_notify.request_for_notify.called)
 
     def test_request_password_change_with_malformed_email(self):
         payload = {'email_address': 'malformed'}

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -480,6 +480,14 @@ class TestRespondents(PartyTestClient):
             account_controller.change_respondent_password(token, {'new_password': 'abc'})
             query.assert_called_once_with('test@example.test', db.session())
 
+    def test_notify_account_lock(self):
+        with patch('ras_party.controllers.account_controller.NotifyGateway'), \
+             patch('ras_party.controllers.account_controller.PublicWebsite'), \
+             patch('ras_party.controllers.account_controller.query_respondent_by_email'):
+            respondent = self.mock_respondent
+            payload = {'email_address': respondent['emailAddress']}
+            self.notify_account_lock(payload, expected_status=200)
+
     def test_verify_token_with_bad_secrets(self):
         # Given a respondent exists with an invalid token
         respondent = self.populate_with_respondent()

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -488,6 +488,11 @@ class TestRespondents(PartyTestClient):
             payload = {'email_address': respondent['emailAddress']}
             self.notify_account_lock(payload, expected_status=200)
 
+    def test_notify_account_lock_with_no_respondent(self):
+        # When the account is locked with no respondents in db
+        payload = {'email_address': 'emailAddress.com'}
+        self.notify_account_lock(payload, expected_status=404)
+
     def test_verify_token_with_bad_secrets(self):
         # Given a respondent exists with an invalid token
         respondent = self.populate_with_respondent()

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -274,7 +274,7 @@ class TestRespondents(PartyTestClient):
         # When the resend verification end point is hit
         self.resend_verification_email(respondent.party_uuid)
         # Verification email is sent
-        self.assertTrue(self.mock_notify.verify_email.called)
+        self.assertTrue(self.mock_notify.request_to_notify.called)
 
     def test_resend_verification_email_responds_with_message(self):
         # Given there is a respondent
@@ -289,7 +289,7 @@ class TestRespondents(PartyTestClient):
         # When the resend verification end point is hit
         response = self.resend_verification_email('3b136c4b-7a14-4904-9e01-13364dd7b972', 404)
         # Then an email is not sent and a message saying there is no respondent is returned
-        self.assertFalse(self.mock_notify.verify_email.called)
+        self.assertFalse(self.mock_notify.request_to_notify.called)
         self.assertIn(account_controller.NO_RESPONDENT_FOR_PARTY_ID, response['errors'])
 
     def test_resend_verification_email_party_id_malformed(self):
@@ -305,10 +305,11 @@ class TestRespondents(PartyTestClient):
         personalisation = {
             'ACCOUNT_VERIFICATION_URL': email
         }
-        self.mock_notify.verify_email.assert_called_once_with(
-            respondent.email_address,
-            personalisation,
-            respondent.party_uuid
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email=respondent.email_address,
+            template_name='email_verification',
+            personalisation=personalisation,
+            reference=respondent.party_uuid
         )
 
     def test_resend_verification_email_sends_to_new_email_address(self):
@@ -321,10 +322,11 @@ class TestRespondents(PartyTestClient):
         personalisation = {
             'ACCOUNT_VERIFICATION_URL': pending_email
         }
-        self.mock_notify.verify_email.assert_called_once_with(
-            respondent.pending_email_address,
-            personalisation,
-            respondent.party_uuid
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email=respondent.pending_email_address,
+            template_name='email_verification',
+            personalisation=personalisation,
+            reference=respondent.party_uuid
         )
 
     def test_request_password_change_with_valid_email(self):
@@ -343,10 +345,11 @@ class TestRespondents(PartyTestClient):
             'RESET_PASSWORD_URL': PublicWebsite().reset_password_url(respondent.email_address),
             'FIRST_NAME': respondent.first_name
         }
-        self.mock_notify.request_password_change.assert_called_once_with(
-            respondent.email_address,
-            personalisation,
-            respondent.party_uuid
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email=respondent.email_address,
+            template_name='request_password_change',
+            personalisation=personalisation,
+            reference=respondent.party_uuid
         )
 
     def test_request_password_change_created_account_doesnt_call_notify_gateway(self):
@@ -383,10 +386,11 @@ class TestRespondents(PartyTestClient):
             'RESET_PASSWORD_URL': PublicWebsite().reset_password_url(respondent.email_address),
             'FIRST_NAME': respondent.first_name
         }
-        self.mock_notify.request_password_change.assert_called_once_with(
-            respondent.email_address,
-            personalisation,
-            respondent.party_uuid
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email=respondent.email_address,
+            template_name='request_password_change',
+            personalisation=personalisation,
+            reference=respondent.party_uuid
         )
 
     @staticmethod
@@ -458,10 +462,11 @@ class TestRespondents(PartyTestClient):
         personalisation = {
             'FIRST_NAME': respondent.first_name
         }
-        self.mock_notify.confirm_password_change.assert_called_once_with(
-            respondent.email_address,
-            personalisation,
-            respondent.party_uuid
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email=respondent.email_address,
+            template_name='confirm_password_change',
+            personalisation=personalisation,
+            reference=uuid.UUID(respondent.party_uuid)
         )
 
     @staticmethod
@@ -565,10 +570,11 @@ class TestRespondents(PartyTestClient):
         personalisation = {
             'ACCOUNT_VERIFICATION_URL': PublicWebsite().activate_account_url('test@example.test'),
         }
-        self.mock_notify.verify_email.assert_called_once_with(
-            'test@example.test',
-            personalisation,
-            respondent.party_uuid
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email='test@example.test',
+            template_name='email_verification',
+            personalisation=personalisation,
+            reference=respondent.party_uuid
         )
 
     def test_email_verification_activates_a_respondent(self):
@@ -584,7 +590,7 @@ class TestRespondents(PartyTestClient):
     def test_email_verification_url_is_from_config_yml_file(self):
         account_controller._send_email_verification(0, 'test@example.test')
         expected_url = 'http://dummy.ons.gov.uk/register/activate-account/'
-        frontstage_url = self.mock_notify.verify_email.call_args[0][1]['ACCOUNT_VERIFICATION_URL']
+        frontstage_url = self.mock_notify.request_to_notify.call_args[1]['personalisation']['ACCOUNT_VERIFICATION_URL']
         self.assertIn(expected_url, frontstage_url)
 
     def test_email_verification_twice_produces_a_200(self):
@@ -729,10 +735,11 @@ class TestRespondents(PartyTestClient):
         personalisation = {
             'ACCOUNT_VERIFICATION_URL': v_url,
         }
-        self.mock_notify.verify_email.assert_called_once_with(
-            self.mock_respondent['emailAddress'],
-            personalisation,
-            str(respondents()[0].party_uuid)
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email=self.mock_respondent['emailAddress'],
+            template_name='email_verification',
+            personalisation=personalisation,
+            reference=str(respondents()[0].party_uuid)
         )
 
     def test_post_respondent_uses_case_insensitive_email_query(self):

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -80,7 +80,6 @@ class TestRespondents(PartyTestClient):
             'business_id': enrolment['business_id'],
             'respondent_id': enrolment['respondent_id'],
             'survey_id': enrolment['survey_id'],
-            'status': enrolment['status'],
             'case_id': 'f8d7a5db-2b72-4409-b4d2-bc47b358cbda',
             'created_on': enrolment['created_on']
         }
@@ -996,6 +995,7 @@ class TestRespondents(PartyTestClient):
                                                respondent_id=respondent.party_uuid)
         enrolment = self.mock_enrolment_pending
         self.populate_with_enrolment(enrolment=enrolment)
+        self.populate_with_pending_enrolment(enrolment=enrolment)
         request_json = {
             'status_change': 'ACTIVE'
         }

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -484,25 +484,24 @@ class TestRespondents(PartyTestClient):
         self.change_password(token, payload, expected_status=404)
 
     def test_change_password_with_valid_token(self):
-        with patch('ras_party.controllers.account_controller._check_enrolment_status_is_enabled', return_value=None):
-            # Given a valid token from the respondent
-            respondent = self.populate_with_respondent()
-            token = self.generate_valid_token_from_email(respondent.email_address)
-            payload = {
-                'new_password': 'password',
-                'token': token
-            }
-            # When the password is changed
-            self.change_password(token, payload, expected_status=200)
-            personalisation = {
-                'FIRST_NAME': respondent.first_name
-            }
-            self.mock_notify.request_to_notify.assert_called_once_with(
-                email=respondent.email_address,
-                template_name='confirm_password_change',
-                personalisation=personalisation,
-                reference=uuid.UUID(respondent.party_uuid)
-            )
+        # Given a valid token from the respondent
+        respondent = self.populate_with_respondent()
+        token = self.generate_valid_token_from_email(respondent.email_address)
+        payload = {
+            'new_password': 'password',
+            'token': token
+        }
+        # When the password is changed
+        self.change_password(token, payload, expected_status=200)
+        personalisation = {
+            'FIRST_NAME': respondent.first_name
+        }
+        self.mock_notify.request_to_notify.assert_called_once_with(
+            email=respondent.email_address,
+            template_name='confirm_password_change',
+            personalisation=personalisation,
+            reference=uuid.UUID(respondent.party_uuid)
+        )
 
     @staticmethod
     def test_change_respondent_password_uses_case_insensitive_email_query():


### PR DESCRIPTION
# Motivation and Context
We needed to add an endpoint, which called notify gateway when a respondent first locks his/hers account. The endpoint tells notify to send an email with instructions about resetting and unlocking account.

# What has changed
New endpoint implemented

# How to test?
Run with fronstage PR [https://github.com/ONSdigital/ras-frontstage/pull/396#pullrequestreview-154559006](url)

Then lock your account, should see link appear in party logs, try resetting password and logging back in. 

