### PR TITLE
206 resend verification if using expired link

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -669,3 +669,15 @@ def get_cases_for_casegroups(casegroup_ids, case_party_id):
     logger.debug('Successfully retrieved cases for casegroups',
                  case_party_id=case_party_id)
     return matching_cases
+
+
+@with_db_session
+def resend_verification_email_expired_token(token, session):
+    email_address = decode_email_token(token, duration=None)
+    respondent = query_respondent_by_email(email_address, session)
+
+    if not respondent:
+        raise ClientError("Respondent does not exist", status=404)
+
+    response = resend_verification_email(respondent.party_uuid)
+    return response

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -422,7 +422,7 @@ def resend_verification_email_by_uuid(party_uuid, session):
     Check and resend an email verification email using the party id
     :param party_uuid: the party uuid
     :param session: database session
-    :return: make_response
+    :return: response
     """
     logger.debug('Attempting to resend verification_email', party_uuid=party_uuid)
 
@@ -440,7 +440,7 @@ def resend_verification_email_expired_token(token, session):
     Check and resend an email verification email using the expired token
     :param token: the expired token
     :param session: database session
-    :return: make_response
+    :return: response
     """
     email_address = decode_email_token(token, duration=None)
     respondent = query_respondent_by_email(email_address, session)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -75,7 +75,7 @@ def put_email_verification(token):
 
 @account_view.route('/resend-verification-email/<party_uuid>', methods=['GET'])
 def resend_verification_email(party_uuid):
-    response = account_controller.resend_verification_email(party_uuid)
+    response = account_controller.resend_verification_email_by_uuid(party_uuid)
     return make_response(jsonify(response), 200)
 
 

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -75,7 +75,6 @@ def put_email_verification(token):
 
 @account_view.route('/resend-verification-email/<party_uuid>', methods=['GET'])
 def resend_verification_email(party_uuid):
-
     response = account_controller.resend_verification_email(party_uuid)
     return make_response(jsonify(response), 200)
 

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -73,13 +73,13 @@ def put_email_verification(token):
     return make_response(jsonify(response), 200)
 
 
-@account_view.route('/resend-verification-email/<party_uuid>', methods=['GET'])
+@account_view.route('/resend-verification-email/<party_uuid>', methods=['POST'])
 def resend_verification_email(party_uuid):
     response = account_controller.resend_verification_email_by_uuid(party_uuid)
     return make_response(jsonify(response), 200)
 
 
-@account_view.route('/resend-verification-email-expired-token/<token>', methods=['GET'])
+@account_view.route('/resend-verification-email-expired-token/<token>', methods=['POST'])
 def resend_verification_email_expired_token(token):
     response = account_controller.resend_verification_email_expired_token(token)
     return make_response(jsonify(response), 200)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -3,9 +3,8 @@ import logging
 import structlog
 from flask import Blueprint, request, current_app, make_response, jsonify
 from flask_httpauth import HTTPBasicAuth
-from itsdangerous import URLSafeTimedSerializer
 
-from ras_party.controllers import account_controller, respondent_controller
+from ras_party.controllers import account_controller
 from ras_party.controllers.validate import Exists, Validator
 from ras_party.exceptions import RasError
 from ras_party.support.log_decorator import log_route
@@ -83,13 +82,7 @@ def resend_verification_email(party_uuid):
 
 @account_view.route('/resend-verification-email-expired-token/<token>', methods=['GET'])
 def resend_verification_email_expired_token(token):
-
-    timed_serializer = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
-    email_token_salt = current_app.config["EMAIL_TOKEN_SALT"]
-
-    email = timed_serializer.loads(token, salt=email_token_salt, max_age=None)
-    respondent = respondent_controller.get_respondent_by_email(email)
-    response = account_controller.resend_verification_email(respondent['id'])
+    response = account_controller.resend_verification_email_expired_token(token)
     return make_response(jsonify(response), 200)
 
 

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -179,14 +179,14 @@ class PartyTestClient(TestCase):
         return json.loads(response.get_data(as_text=True))
 
     def resend_verification_email(self, party_uuid, expected_status=200):
-        response = self.client.get(f'/party-api/v1/resend-verification-email/{party_uuid}',
-                                   headers=self.auth_headers)
+        response = self.client.post(f'/party-api/v1/resend-verification-email/{party_uuid}',
+                                    headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
     def resend_verification_email_expired_token(self, token, expected_status=200):
-        response = self.client.get(f'/party-api/v1/resend-verification-email-expired-token/{token}',
-                                   headers=self.auth_headers)
+        response = self.client.post(f'/party-api/v1/resend-verification-email-expired-token/{token}',
+                                    headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -184,6 +184,12 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
+    def resend_verification_email_expired_token(self, token, expected_status=200):
+        response = self.client.get(f'/party-api/v1/resend-verification-email-expired-token/{token}',
+                                   headers=self.auth_headers)
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))
+
     def request_password_change(self, payload, expected_status=200):
         response = self.client.post('/party-api/v1/respondents/request_password_change',
                                     data=json.dumps(payload),

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -178,8 +178,8 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def resend_verification_email(self, email, expected_status=200):
-        response = self.client.get(f'/party-api/v1/resend-verification-email/{email}',
+    def resend_verification_email(self, party_uuid, expected_status=200):
+        response = self.client.get(f'/party-api/v1/resend-verification-email/{party_uuid}',
                                    headers=self.auth_headers)
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -324,7 +324,7 @@ class TestRespondents(PartyTestClient):
         # The token is valid but the respondent doesn't exist
         current_app.config['EMAIL_TOKEN_EXPIRY'] = -1
         token = self.generate_valid_token_from_email('invalid@email.com')
-        #When the resend verification with expired token endpoint is hit
+        # When the resend verification with expired token endpoint is hit
         response = self.resend_verification_email_expired_token(token, 404)
         # Then an email is not sent and a message saying there is no respondent is returned
         self.assertFalse(self.mock_notify.verify_email.called)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -320,6 +320,16 @@ class TestRespondents(PartyTestClient):
         # Then a notification is sent the the respondent's email adddress
         self.assertTrue(self.mock_notify.verify_email.called)
 
+    def test_resend_verification_email_expired_token_respondent_not_found(self):
+        # The token is valid but the respondent doesn't exist
+        current_app.config['EMAIL_TOKEN_EXPIRY'] = -1
+        token = self.generate_valid_token_from_email('invalid@email.com')
+        #When the resend verification with expired token endpoint is hit
+        response = self.resend_verification_email_expired_token(token, 404)
+        # Then an email is not sent and a message saying there is no respondent is returned
+        self.assertFalse(self.mock_notify.verify_email.called)
+        self.assertIn("Respondent does not exist", response['errors'])
+
     def test_resend_verification_email_sends_to_new_email_address(self):
         # Given there is a respondent with a pending email address
         respondent = self.populate_with_respondent(respondent=self.mock_respondent_with_pending_email)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1,6 +1,5 @@
 # pylint: disable=no-value-for-parameter
 
-import time
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -612,10 +611,8 @@ class TestRespondents(PartyTestClient):
 
     def test_email_verification_expired_token_produces_a_409(self):
         respondent = self.populate_with_respondent()
-        current_app.config['EMAIL_TOKEN_EXPIRY'] = 0
+        current_app.config['EMAIL_TOKEN_EXPIRY'] = -1
         token = self.generate_valid_token_from_email(respondent.email_address)
-        # expire the token
-        time.sleep(1)
         self.put_email_verification(token, 409)
 
     def test_email_verification_unknown_email_produces_a_404(self):

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-value-for-parameter
 
+import time
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -311,6 +312,15 @@ class TestRespondents(PartyTestClient):
             respondent.party_uuid
         )
 
+    def test_email_verification_expired_token_sends_calls_notify(self):
+        # Given a token is used that has already been declared to be expired
+        respondent = self.populate_with_respondent()
+        token = self.generate_valid_token_from_email(respondent.email_address)
+        # When the resend verification with expired token endpoint is hit
+        self.resend_verification_email_expired_token(token)
+        # Then a notification is sent the the respondent's email adddress
+        self.assertTrue(self.mock_notify.verify_email.called)
+
     def test_resend_verification_email_sends_to_new_email_address(self):
         # Given there is a respondent with a pending email address
         respondent = self.populate_with_respondent(respondent=self.mock_respondent_with_pending_email)
@@ -599,6 +609,14 @@ class TestRespondents(PartyTestClient):
         timed_serializer = URLSafeTimedSerializer(secret_key)
         token = timed_serializer.dumps(self.mock_respondent['emailAddress'], salt='salt')
         self.put_email_verification(token, 404)
+
+    def test_email_verification_expired_token_produces_a_409(self):
+        respondent = self.populate_with_respondent()
+        current_app.config['EMAIL_TOKEN_EXPIRY'] = 0
+        token = self.generate_valid_token_from_email(respondent.email_address)
+        # expire the token
+        time.sleep(1)
+        self.put_email_verification(token, 409)
 
     def test_email_verification_unknown_email_produces_a_404(self):
         self.populate_with_respondent()


### PR DESCRIPTION
# Motivation and Context
If an expired verification link is attempted, we need to give the external user an opportunity to resend the verification link to their registered email address.  When they attempt the link, all we know is the token so there needs to be a new way to be able to resend a link using only the token.

# What has changed
- New endpoint which will be called from frontstage and given the expired token.
- Added tests.

# How to test?
- Set `EMAIL_TOKEN_EXPIRY` to 0 so that tokens are immediately expired (otherwise you'll be waiting 80 hours for it to expire).
- Run alongside branch `206-resend-verification-if-using-expired-link` in ras-frontstage.
- A new verification link should be generated when the new endpoint is hit from frontstage (check the logs when testing).
- All tests should pass.

# Links
- https://trello.com/c/fqc35BzO
