### PR TITLE
207 resend password reset link if expired

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -335,7 +335,6 @@ def request_password_change(payload, session):
 
 
 @with_db_session
-
 def resend_password_email_expired_token(token, session):
     """
     Check and resend an email verification email using the expired token

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -324,6 +324,26 @@ def request_password_change(payload, session):
 
 
 @with_db_session
+def resend_password_email_expired_token(token, session):
+    """
+    Check and resend an email verification email using the expired token
+    :param token: the expired token
+    :param session: database session
+    :return: response
+    """
+    email_address = decode_email_token(token, duration=None)
+    respondent = query_respondent_by_email(email_address, session)
+
+    if not respondent:
+        raise ClientError("Respondent does not exist", status=404)
+
+    payload = {'email_address': email_address}
+
+    response = request_password_change(payload)
+    return response
+
+
+@with_db_session
 def change_respondent_account_status(payload, party_id, session):
 
     status = payload['status_change']

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -85,6 +85,12 @@ def resend_verification_email_expired_token(token):
     return make_response(jsonify(response), 200)
 
 
+@account_view.route('/resend-password-email-expired-token/<token>', methods=['POST'])
+def resend_password_email_expired_token(token):
+    response = account_controller.resend_password_email_expired_token(token)
+    return make_response(jsonify(response), 200)
+
+
 @account_view.route('/respondents/add_survey', methods=['POST'])
 def respondent_add_survey():
     payload = request.get_json() or {}

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -190,6 +190,12 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
+    def resend_password_email_expired_token(self, token, expected_status=200):
+        response = self.client.post(f'/party-api/v1/resend-password-email-expired-token/{token}',
+                                    headers=self.auth_headers)
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))
+
     def request_password_change(self, payload, expected_status=200):
         response = self.client.post('/party-api/v1/respondents/request_password_change',
                                     data=json.dumps(payload),

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -522,7 +522,7 @@ class TestRespondents(PartyTestClient):
         # When the resend password with expired token endpoint is hit
         self.resend_password_email_expired_token(token)
         # Then a notification is sent the the respondent's email adddress
-        self.assertTrue(self.mock_notify.request_password_change.called)
+        self.assertTrue(self.mock_notify.request_to_notify.called)
 
     def test_resend_password_email_expired_token_respondent_not_found(self):
         # The token is valid but the respondent doesn't exist
@@ -530,7 +530,7 @@ class TestRespondents(PartyTestClient):
         # When the resend verification with expired token endpoint is hit
         response = self.resend_password_email_expired_token(token, 404)
         # Then an email is not sent and a message saying there is no respondent is returned
-        self.assertFalse(self.mock_notify.request_password_change.called)
+        self.assertFalse(self.mock_notify.request_to_notify.called)
         self.assertIn("Respondent does not exist", response['errors'])
 
     @staticmethod

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -494,6 +494,24 @@ class TestRespondents(PartyTestClient):
             account_controller.change_respondent_password(token, {'new_password': 'abc'})
             query.assert_called_once_with('test@example.test', db.session())
 
+    def test_resend_password_email_expired_token_calls_notify(self):
+        # Given a token is used that has already been declared to be expired
+        respondent = self.populate_with_respondent(respondent=self.mock_respondent_with_id_active)
+        token = self.generate_valid_token_from_email(respondent.email_address)
+        # When the resend password with expired token endpoint is hit
+        self.resend_password_email_expired_token(token)
+        # Then a notification is sent the the respondent's email adddress
+        self.assertTrue(self.mock_notify.request_password_change.called)
+
+    def test_resend_password_email_expired_token_respondent_not_found(self):
+        # The token is valid but the respondent doesn't exist
+        token = self.generate_valid_token_from_email('invalid@email.com')
+        # When the resend verification with expired token endpoint is hit
+        response = self.resend_password_email_expired_token(token, 404)
+        # Then an email is not sent and a message saying there is no respondent is returned
+        self.assertFalse(self.mock_notify.request_password_change.called)
+        self.assertIn("Respondent does not exist", response['errors'])
+
     def test_verify_token_with_bad_secrets(self):
         # Given a respondent exists with an invalid token
         respondent = self.populate_with_respondent()


### PR DESCRIPTION
# Motivation and Context
When a respondent requests a change of password, they are emailed a link that expires after 80 hours.  If they try to use the link after the 80 hours then they are redirected to a page that tells them to phone us for another link.  This PR allows the respondent to generate a new link which is then sent to the email registered to their account.

# What has changed
<!--- What code changes has been made -->
New endpoint which takes an expired token, decodes it, generates a new token and sends it to the registered email address of the user.

# How to test?
- Set the EMAIL_TOKEN_EXPIRY to -1 so that tokens expire as soon as they're created (otherwise you'll be waiting 80 hours for one to expire)
- Run this branch alongside `207-resend-password-reset-link-if-expired` in frontstage
- In frontstage, request a password reset for an active account - check the party logs to find it
- Follow the link to reset the password.  The link should be expired and you should be redirected to a page and given the option to resend a password reset link
- Click the link to send another and check in the party logs that another link has been generated.
- You should finally be redirected to the 'Check your email page'
- The new link that's been generated in party should allow you to reset your password as normal (if you change the EMAIL_TOKEN_EXPIRY back)

# Links
- https://trello.com/c/1FXbQiA2