### PR TITLE
Replace generic 'RasError' and 'ClientError'

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -5,7 +5,7 @@ import structlog
 from flask import current_app
 from itsdangerous import SignatureExpired, BadSignature, BadData
 from requests import HTTPError
-from sqlalchemy import orm
+from werkzeug.exceptions import BadRequest, Conflict, InternalServerError,  NotFound
 
 from ras_party.clients.oauth_client import OauthClient
 from ras_party.controllers.notify_gateway import NotifyGateway
@@ -15,7 +15,7 @@ from ras_party.controllers.queries import query_enrolment_by_survey_business_res
 from ras_party.controllers.queries import query_respondent_by_email, query_respondent_by_pending_email
 from ras_party.controllers.queries import query_respondent_by_party_uuid, query_business_by_party_uuid
 from ras_party.controllers.validate import Exists, Validator
-from ras_party.exceptions import ClientError, RasError, RasNotifyError
+from ras_party.exceptions import RasNotifyError
 from ras_party.models.models import BusinessRespondent, Enrolment, EnrolmentStatus
 from ras_party.models.models import PendingEnrolment, Respondent, RespondentStatus
 from ras_party.support.public_website import PublicWebsite
@@ -61,37 +61,35 @@ def post_respondent(party, tran, session):
         try:
             uuid.UUID(party['id'])
         except ValueError:
-            raise ClientError(f"'{party['id']}' is not a valid UUID format for property 'id'", status=400)
+            logger.debug("Invalid respondent id type", respondent_id=party['id'])
+            raise BadRequest(f"'{party['id']}' is not a valid UUID format for property 'id'")
 
     if not v.validate(party):
-        raise ClientError(v.errors, 400)
+        logger.debug(v.errors)
+        raise BadRequest(v.errors)
 
     iac = request_iac(party['enrolmentCode'])
     if not iac.get('active'):
-        raise ClientError("Enrolment code is not active", status=400)
+        logger.debug("Inactive enrolment code")
+        raise BadRequest("Enrolment code is not active")
 
     existing = query_respondent_by_email(party['emailAddress'], session)
     if existing:
-        raise ClientError("Email address already exists",
-                          status=400,
-                          party_uuid=str(existing.party_uuid))
+        logger.debug("Email already exists", party_uuid=str(existing.party_uuid))
+        raise BadRequest("Email address already exists")
 
     case_context = request_case(party['enrolmentCode'])
     case_id = case_context['id']
     business_id = case_context['partyId']
     collection_exercise_id = case_context['caseGroup']['collectionExerciseId']
     collection_exercise = request_collection_exercise(collection_exercise_id)
-
-    try:
-        survey_id = collection_exercise['surveyId']
-    except KeyError:
-        raise ClientError("There is no survey bound for this user", party_uuid=party['party_uuid'])
+    survey_id = collection_exercise['surveyId']
 
     business = query_business_by_party_uuid(business_id, session)
     if not business:
-        raise ClientError("Could not locate business when creating business association",
-                          business_id=business_id,
-                          status=404)
+        logger.error("Could not locate business when creating business association",
+                     business_id=business_id, case_id=case_id, collection_exercise_id=collection_exercise_id)
+        raise InternalServerError("Could not locate business when creating business association")
 
     # Chain of enrolment processes
     translated_party = {
@@ -103,36 +101,26 @@ def post_respondent(party, tran, session):
         'status': RespondentStatus.CREATED
     }
 
-    try:
-        #  Create the enrolment respondent-business-survey associations
-        respondent = Respondent(**translated_party)
-        br = BusinessRespondent(business=business, respondent=respondent)
-        pending_enrolment = PendingEnrolment(case_id=case_id,
-                                             respondent=respondent,
-                                             business_id=business_id,
-                                             survey_id=survey_id)
-        Enrolment(business_respondent=br,
-                  survey_id=survey_id,
-                  status=EnrolmentStatus.PENDING)
-        session.add(respondent)
-        session.add(pending_enrolment)
+    #  Create the enrolment respondent-business-survey associations
+    respondent = Respondent(**translated_party)
+    br = BusinessRespondent(business=business, respondent=respondent)
+    pending_enrolment = PendingEnrolment(case_id=case_id,
+                                         respondent=respondent,
+                                         business_id=business_id,
+                                         survey_id=survey_id)
+    Enrolment(business_respondent=br,
+              survey_id=survey_id,
+              status=EnrolmentStatus.PENDING)
+    session.add(respondent)
+    session.add(pending_enrolment)
 
-        # Notify the case service of this account being created
-        post_case_event(case_id,
-                        respondent.party_uuid,
-                        "RESPONDENT_ACCOUNT_CREATED",
-                        "New respondent account created")
+    # Notify the case service of this account being created
+    post_case_event(case_id,
+                    respondent.party_uuid,
+                    "RESPONDENT_ACCOUNT_CREATED",
+                    "New respondent account created")
 
-        _send_email_verification(respondent.party_uuid, party['emailAddress'])
-    except (orm.exc.ObjectDeletedError, orm.exc.FlushError, orm.exc.StaleDataError, orm.exc.DetachedInstanceError):
-        logger.error('Error updating database for user', party_id=party['id'])
-        raise RasError("Error updating database for user", status=500, party_id=party['id'])
-    except KeyError:
-        logger.error('Missing config keys during enrolment')
-        raise RasError('Missing config keys during enrolment', status=500)
-    except Exception:
-        logger.exception('Error during enrolment process')
-        raise RasError("Error during enrolment process", status=500)
+    _send_email_verification(respondent.party_uuid, party['emailAddress'])
 
     register_user(party, tran)
 
@@ -158,8 +146,8 @@ def change_respondent_enrolment_status(payload, session):
                 status=change_flag)
     respondent = query_respondent_by_party_uuid(respondent_id, session)
     if not respondent:
-        raise ClientError("Respondent does not exist",
-                          respondent_id=respondent_id, status=404)
+        logger.debug("Respondent does not exist", respondent_id=respondent_id)
+        raise NotFound("Respondent does not exist")
 
     enrolment = query_enrolment_by_survey_business_respondent(respondent_id=respondent.id,
                                                               business_id=business_id,
@@ -193,7 +181,8 @@ def change_respondent(payload, session):
     """
     v = Validator(Exists('email_address', 'new_email_address'))
     if not v.validate(payload):
-        raise ClientError(v.errors, 400)
+        logger.debug(v.errors)
+        raise BadRequest(v.errors, 400)
 
     email_address = payload['email_address']
     new_email_address = payload['new_email_address']
@@ -201,14 +190,16 @@ def change_respondent(payload, session):
     respondent = query_respondent_by_email(email_address, session)
 
     if not respondent:
-        raise ClientError("Respondent does not exist", status=404)
+        logger.debug("Respondent does not exist")
+        raise NotFound("Respondent does not exist")
 
     if new_email_address == email_address:
         return respondent.to_respondent_dict()
 
     respondent_with_new_email = query_respondent_by_email(new_email_address, session)
     if respondent_with_new_email:
-        raise ClientError("New email address already taken", status=409)
+        logger.debug("Respondent with email already exists")
+        raise Conflict("New email address already taken")
 
     respondent.pending_email_address = new_email_address
 
@@ -225,13 +216,16 @@ def verify_token(token, session):
         duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
         email_address = decode_email_token(token, duration)
     except SignatureExpired:
-        raise ClientError('Expired email verification token', status=409, token=token)
-    except (BadSignature, BadData) as e:
-        raise ClientError('Unknown email verification token', status=404, token=token, error=e)
+        logger.info("Expired email verification token")
+        raise Conflict("Expired email verification token")
+    except (BadSignature, BadData):
+        logger.exception("Bad token")
+        raise NotFound("Unknown email verification token")
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise ClientError("Respondent does not exist", status=404)
+        logger.debug("Respondent with Email from token does not exist")
+        raise NotFound("Respondent does not exist")
 
     return {'response': "Ok"}
 
@@ -245,14 +239,16 @@ def change_respondent_password(token, payload, tran, session):
         duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
         email_address = decode_email_token(token, duration)
     except SignatureExpired:
-        raise ClientError('Expired email verification token', status=409, token=token)
-    except (BadSignature, BadData) as e:
-        raise ClientError('Unknown email verification token', status=404, token=token, error=e)
+        logger.info("Expired email verification token")
+        raise Conflict("Expired email verification token")
+    except (BadSignature, BadData):
+        logger.exception("Bad token")
+        raise NotFound("Unknown email verification token")
 
     respondent = query_respondent_by_email(email_address, session)
     if not respondent:
-        raise ClientError("Respondent does not exist",
-                          status=404)
+        logger.debug("Respondent with Email from token does not exist")
+        raise NotFound("Respondent does not exist")
 
     new_password = payload['new_password']
 
@@ -275,7 +271,9 @@ def change_respondent_password(token, payload, tran, session):
             password=new_password)
 
     if oauth_response.status_code != 201:
-        raise RasError("Failed to change respondent password")
+        logger.error("Unexpected response from auth service, unable to change user password",
+                     respondent_id=str(respondent.party_uuid), status=oauth_response.status_code)
+        raise InternalServerError("Failed to change respondent password")
 
     personalisation = {
         'FIRST_NAME': respondent.first_name
@@ -303,7 +301,8 @@ def request_password_change(payload, session):
 
     respondent = query_respondent_by_email(payload['email_address'], session)
     if not respondent:
-        raise ClientError("Respondent does not exist", status=404)
+        logger.debug("Respondent does not exist")
+        raise NotFound("Respondent does not exist")
 
     logger.debug("Requesting password change", party_id=respondent.party_uuid)
 
@@ -346,7 +345,8 @@ def resend_password_email_expired_token(token, session):
     respondent = query_respondent_by_email(email_address, session)
 
     if not respondent:
-        raise ClientError("Respondent does not exist", status=404)
+        logger.debug("Respondent does not exist")
+        raise NotFound("Respondent does not exist")
 
     payload = {'email_address': email_address}
 
@@ -360,8 +360,9 @@ def notify_change_account_status(payload, party_id, session):
 
     respondent = query_respondent_by_party_uuid(party_id, session)
     if not respondent:
-        raise ClientError('Respondent does not exist', respondent_id=party_id,
-                          status=404)
+        logger.debug("Respondent does not exist")
+        raise NotFound("Respondent does not exist")
+
     email_address = respondent.email_address
 
     # Unlock respondents account
@@ -375,7 +376,9 @@ def notify_change_account_status(payload, party_id, session):
         try:
             oauth_response.raise_for_status()
         except HTTPError:
-            raise RasError('Failed to unlock respondent account', respondent_id=str(respondent.party_uuid))
+            logger.error("Unexpected response from auth service, unable to unlock account",
+                         respondent_id=str(respondent.party_uuid), status=oauth_response.status_code)
+            raise InternalServerError('Failed to unlock respondent account')
 
         logger.debug('Respondent account updated', respondent_id=party_id)
 
@@ -419,9 +422,11 @@ def put_email_verification(token, tran, session):
         duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
         email_address = decode_email_token(token, duration)
     except SignatureExpired:
-        raise ClientError('Expired email verification token', status=409, token=token)
-    except (BadSignature, BadData) as e:
-        raise ClientError('Bad email verification token', status=404, token=token, error=e)
+        logger.info("Expired email verification token")
+        raise Conflict("Expired email verification token")
+    except (BadSignature, BadData):
+        logger.exception("Bad token")
+        raise NotFound("Unknown email verification token")
 
     respondent = query_respondent_by_email(email_address, session)
 
@@ -433,7 +438,8 @@ def put_email_verification(token, tran, session):
         if respondent:
             update_verified_email_address(respondent, tran, session)
         else:
-            raise ClientError("Unable to find user while checking email verification token", status=404)
+            logger.info("Unable to find respondent by pending email")
+            raise NotFound("Unable to find user while checking email verification token")
 
     if respondent.status != RespondentStatus.ACTIVE:
         # We set the party as ACTIVE in this service
@@ -465,7 +471,9 @@ def update_verified_email_address(respondent, tran, session):
         account_verified='true')
 
     if oauth_response.status_code != 201:
-        raise RasError("Failed to change respondent email", respondent_id=str(respondent.party_uuid))
+        logger.error("Unexpected response from auth service, unable to change user email",
+                     respondent_id=str(respondent.party_uuid), status=oauth_response.status_code)
+        raise InternalServerError("Failed to change respondent email")
 
     def compensate_oauth_change():
         rollback_response = OauthClient().update_account(
@@ -475,9 +483,9 @@ def update_verified_email_address(respondent, tran, session):
         respondent.pending_email_address = new_email_address
 
         if rollback_response.status_code != 201:
-            logger.error("Failed to rollback change to respondent email. Please investigate.",
-                         party_id=respondent.party_uuid)
-            raise RasError("Failed to rollback change to respondent email")
+            logger.error("Unexpected response from auth service, unable to rollback change to respondent email",
+                         respondent_id=str(respondent.party_uuid), status=oauth_response.status_code)
+            raise InternalServerError("Failed to rollback change to respondent email")
 
     tran.compensate(compensate_oauth_change)
 
@@ -499,7 +507,7 @@ def resend_verification_email_by_uuid(party_uuid, session):
 
     respondent = query_respondent_by_party_uuid(party_uuid, session)
     if not respondent:
-        raise ClientError(NO_RESPONDENT_FOR_PARTY_ID, status=404)
+        raise NotFound(NO_RESPONDENT_FOR_PARTY_ID)
 
     response = _resend_verification_email(respondent)
     return response
@@ -517,7 +525,8 @@ def resend_verification_email_expired_token(token, session):
     respondent = query_respondent_by_email(email_address, session)
 
     if not respondent:
-        raise ClientError("Respondent does not exist", status=404)
+        logger.debug("Respondent does not exist")
+        raise NotFound("Respondent does not exist")
 
     response = _resend_verification_email(respondent)
     return response
@@ -547,7 +556,8 @@ def add_new_survey_for_respondent(payload, tran, session):
 
     iac = request_iac(enrolment_code)
     if not iac.get('active'):
-        raise ClientError("Enrolment code is not active", status=400)
+        logger.debug("Inactive enrolment code")
+        raise BadRequest("Enrolment code is not active")
 
     respondent = query_respondent_by_party_uuid(respondent_party_id, session)
 
@@ -567,9 +577,9 @@ def add_new_survey_for_respondent(payload, tran, session):
         """
         business = query_business_by_party_uuid(business_id, session)
         if not business:
-            raise ClientError("Could not locate business when creating business association",
-                              business_id=business_id,
-                              status=404)
+            logger.error("Could not find business", business_id=business_id, case_id=case_id,
+                         collection_exercise_id=collection_exercise_id)
+            raise InternalServerError("Could not locate business when creating business association")
         br = BusinessRespondent(business=business, respondent=respondent)
 
     enrolment = Enrolment(business_respondent=br,
@@ -773,4 +783,5 @@ def _is_valid(payload, attribute):
     v = Validator(Exists(attribute))
     if v.validate(payload):
         return True
-    raise ClientError(v.errors, 400)
+    logger.debug(v.errors)
+    raise BadRequest(v.errors, 400)

--- a/ras_party/exceptions.py
+++ b/ras_party/exceptions.py
@@ -1,34 +1,5 @@
-class ClientError(Exception):
+class RasNotifyError(Exception):
 
-    def __init__(self, errors, status=400, **kwargs):
-        self.errors = errors if isinstance(errors, list) else [errors]
-        self.status_code = status or RasPartyError.status_code
-        self.kwargs = kwargs
-
-    def to_dict(self):
-        return {'errors': self.errors}
-
-
-class RasError(Exception):
-
-    status_code = 500
-
-    def __init__(self, errors, status=None, **kwargs):
-        self.errors = errors if isinstance(errors, list) else [errors]
-        self.status_code = status or RasPartyError.status_code
-        self.kwargs = kwargs
-
-    def to_dict(self):
-        return {'errors': self.errors}
-
-
-class RasDatabaseError(RasError):
-    pass
-
-
-class RasPartyError(RasError):
-    pass
-
-
-class RasNotifyError(RasError):
-    pass
+    def __init__(self, description=None, error=None):
+        self.description = description
+        self.error = error

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -10,8 +10,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Enum
+from werkzeug.exceptions import NotFound
 
-from ras_party.exceptions import RasError
 from ras_party.models import GUID
 from ras_party.support.util import filter_falsey_values, partition_dict
 
@@ -157,9 +157,8 @@ class Business(Base):
         try:
             return next((attributes for attributes in self.attributes if attributes.collection_exercise))
         except StopIteration:
-            logger.error("No active attributes for business", party_id=self.party_uuid)
-            raise RasError("Business with reference does not have any active attributes.", reference=self.business_ref,
-                           status=404)
+            logger.error("No active attributes for business", reference=self.business_ref, status=404)
+            raise NotFound("Business with reference does not have any active attributes.")
 
 
 class BusinessAttributes(Base):

--- a/ras_party/support/session_decorator.py
+++ b/ras_party/support/session_decorator.py
@@ -4,8 +4,6 @@ from functools import wraps
 import structlog
 from flask import current_app
 
-from ras_party.exceptions import ClientError, RasError
-
 
 logger = structlog.wrap_logger(logging.getLogger(__name__))
 
@@ -22,14 +20,6 @@ def handle_session(f, args, kwargs):
         logger.info("Committing database session.")
         session.commit()
         return result
-    except ClientError:
-        logger.info("Rolling back database session due to a ClientError")
-        session.rollback()
-        raise
-    except RasError:
-        logger.info("Rolling back database session due to failure executing function")
-        session.rollback()
-        raise
     except Exception:
         logger.info("Rolling back database session due to uncaught exception")
         session.rollback()

--- a/ras_party/support/verification.py
+++ b/ras_party/support/verification.py
@@ -3,8 +3,7 @@ import logging
 import structlog
 from flask import current_app
 from itsdangerous import URLSafeTimedSerializer
-
-from ras_party.exceptions import RasError
+from werkzeug.exceptions import InternalServerError
 
 
 logger = structlog.wrap_logger(logging.getLogger(__name__))
@@ -18,7 +17,7 @@ def generate_email_token(email):
     if secret_key is None or email_token_salt is None:
         msg = "SECRET_KEY or EMAIL_TOKEN_SALT are not configured."
         logger.error(msg)
-        raise RasError(msg)
+        raise InternalServerError(msg)
 
     timed_serializer = URLSafeTimedSerializer(secret_key)
     return timed_serializer.dumps(email, salt=email_token_salt)

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -3,10 +3,10 @@ import logging
 import structlog
 from flask import Blueprint, request, current_app, make_response, jsonify
 from flask_httpauth import HTTPBasicAuth
+from werkzeug.exceptions import BadRequest
 
 from ras_party.controllers import account_controller
 from ras_party.controllers.validate import Exists, Validator
-from ras_party.exceptions import RasError
 from ras_party.support.log_decorator import log_route
 
 
@@ -96,7 +96,8 @@ def respondent_add_survey():
     payload = request.get_json() or {}
     v = Validator(Exists('party_id', 'enrolment_code'))
     if not v.validate(payload):
-        raise RasError(v.errors, 400)
+        logger.debug(v.errors, url=request.url)
+        raise BadRequest(v.errors)
 
     account_controller.add_new_survey_for_respondent(payload)
     return make_response(jsonify('OK'), 200)
@@ -107,7 +108,8 @@ def change_respondent_enrolment_status():
     payload = request.get_json() or {}
     v = Validator(Exists('respondent_id', 'business_id', 'survey_id', 'change_flag'))
     if not v.validate(payload):
-        raise RasError(v.errors, 400)
+        logger.debug(v.errors, url=request.url)
+        raise BadRequest(v.errors)
     account_controller.change_respondent_enrolment_status(payload)
 
     return make_response(jsonify('OK'), 200)
@@ -120,7 +122,8 @@ def put_edit_account_status(party_id):
     payload = request.get_json() or {}
     v = Validator(Exists('status_change'))
     if not v.validate(payload):
-        raise RasError(v.errors, 400)
+        logger.debug(v.errors, url=request.url)
+        raise BadRequest(v.errors)
 
     response = account_controller.notify_change_account_status(payload=payload, party_id=party_id)
     return make_response(jsonify(response), 200)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -1,11 +1,15 @@
+import logging
+
+import structlog
 from flask import Blueprint, current_app, make_response, jsonify, request
 from flask_httpauth import HTTPBasicAuth
+from werkzeug.exceptions import BadRequest
 
 from ras_party.controllers import respondent_controller
-from ras_party.exceptions import RasError
 from ras_party.support.log_decorator import log_route
 
 
+logger = structlog.wrap_logger(logging.getLogger(__name__))
 respondent_view = Blueprint('respondent_view', __name__)
 auth = HTTPBasicAuth()
 
@@ -33,7 +37,8 @@ def get_respondents():
         # pylint: disable=no-value-for-parameter
         response = respondent_controller.get_respondent_by_ids(ids)
     else:
-        raise RasError("The parameter id is required.", status=400)
+        logger.debug("The parameter id is required.", url=request.url)
+        raise BadRequest("The parameter id is required.")
 
     return jsonify(response)
 

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -104,7 +104,7 @@ class TestParties(PartyTestClient):
     def test_get_business_by_ids_fails_if_id_is_not_uuid(self):
         party_uuid = "gibberish"
         response = self.get_businesses_by_ids([party_uuid], expected_status=400)
-        self.assertEquals(response['errors'][0], """'gibberish' is not a valid UUID format for property 'id'""")
+        self.assertEquals(response['description'], """'gibberish' is not a valid UUID format for property 'id'""")
 
     def test_get_business_by_id_with_no_active_attributes_returns_404(self):
         mock_business = MockBusiness() \

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -6,10 +6,12 @@ from unittest.mock import MagicMock, patch
 
 from flask import current_app
 from itsdangerous import URLSafeTimedSerializer
+from requests import Response
+from werkzeug.exceptions import BadRequest, InternalServerError
 
 from ras_party.controllers import account_controller
 from ras_party.controllers.queries import query_respondent_by_party_uuid, query_business_by_party_uuid
-from ras_party.exceptions import ClientError, RasNotifyError
+from ras_party.exceptions import RasNotifyError
 from ras_party.models.models import BusinessRespondent, Enrolment, RespondentStatus, Respondent, PendingEnrolment
 from ras_party.support.public_website import PublicWebsite
 from ras_party.support.requests_wrapper import Requests
@@ -181,7 +183,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent()
         party_uuid = "gibberish"
         response = self.get_respondents_by_ids([party_uuid], expected_status=400)
-        self.assertEquals(response['errors'][0], """'gibberish' is not a valid UUID format for property 'id'""")
+        self.assertEquals(response['description'], """'gibberish' is not a valid UUID format for property 'id'""")
 
     def test_get_respondent_by_ids_with_an_unknown_id_still_returns_correct_representation_for_other_ids(self):
         respondent_1 = MockRespondent()
@@ -306,7 +308,7 @@ class TestRespondents(PartyTestClient):
         response = self.resend_verification_email('3b136c4b-7a14-4904-9e01-13364dd7b972', 404)
         # Then an email is not sent and a message saying there is no respondent is returned
         self.assertFalse(self.mock_notify.request_to_notify.called)
-        self.assertIn(account_controller.NO_RESPONDENT_FOR_PARTY_ID, response['errors'])
+        self.assertIn(account_controller.NO_RESPONDENT_FOR_PARTY_ID, response['description'])
 
     def test_resend_verification_email_party_id_malformed(self):
         self.resend_verification_email('malformed', 500)
@@ -345,7 +347,7 @@ class TestRespondents(PartyTestClient):
         response = self.resend_verification_email_expired_token(token, 404)
         # Then an email is not sent and a message saying there is no respondent is returned
         self.assertFalse(self.mock_notify.request_to_notify.called)
-        self.assertIn("Respondent does not exist", response['errors'])
+        self.assertIn("Respondent does not exist", response['description'])
 
     def test_resend_verification_email_sends_to_new_email_address(self):
         # Given there is a respondent with a pending email address
@@ -531,7 +533,7 @@ class TestRespondents(PartyTestClient):
         response = self.resend_password_email_expired_token(token, 404)
         # Then an email is not sent and a message saying there is no respondent is returned
         self.assertFalse(self.mock_notify.request_to_notify.called)
-        self.assertIn("Respondent does not exist", response['errors'])
+        self.assertIn("Respondent does not exist", response['description'])
 
     @staticmethod
     def test_change_respondent_password_ras_notify_error():
@@ -728,9 +730,9 @@ class TestRespondents(PartyTestClient):
         self.populate_with_business()
         self.post_to_respondents(self.mock_respondent, 200)
 
-    def test_post_respondent_without_business_returns_404(self):
+    def test_post_respondent_without_business_returns_500(self):
         self.assertEqual(len(businesses()), 0)
-        self.post_to_respondents(self.mock_respondent, 404)
+        self.post_to_respondents(self.mock_respondent, 500)
 
     def test_post_respondent_with_no_payload_returns_400(self):
         self.post_to_respondents(None, 400)
@@ -746,7 +748,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_business()
         self.post_to_respondents(self.mock_respondent, 200)
         response = self.post_to_respondents(self.mock_respondent, 400)
-        self.assertIn('Email address already exists', response['errors'][0])
+        self.assertIn('Email address already exists', response['description'])
 
     def test_post_respondent_twice_different_email(self):
         self.populate_with_business()
@@ -860,7 +862,7 @@ class TestRespondents(PartyTestClient):
                 'enrolmentCode': 'abc'
             }
             query('test@example.test', db.session()).return_value = None
-            with self.assertRaises(ClientError):
+            with self.assertRaises(BadRequest):
                 account_controller.post_respondent(payload)
             query.assert_called_once_with('test@example.test', db.session())
 
@@ -900,7 +902,7 @@ class TestRespondents(PartyTestClient):
             'enrolment_code': self.mock_respondent_with_id['enrolment_code']
         }
         response = self.add_survey(request_json, 400)
-        self.assertTrue(response['errors'] == ["Required key 'party_id' is missing."])
+        self.assertTrue(response['description'] == ["Required key 'party_id' is missing."])
 
     def test_post_add_new_survey_missing_enrolment_code_returns_error(self):
         self.populate_with_respondent(respondent=self.mock_respondent_with_id)
@@ -915,7 +917,7 @@ class TestRespondents(PartyTestClient):
         }
 
         response = self.add_survey(request_json, 400)
-        self.assertTrue(response['errors'] == ["Required key 'enrolment_code' is missing."])
+        self.assertTrue(response['description'] == ["Required key 'enrolment_code' is missing."])
 
     def test_post_add_survey_inactive_enrolment_code(self):
         # Set IAC code to be inactive
@@ -934,7 +936,7 @@ class TestRespondents(PartyTestClient):
 
         self.add_survey(request_json, 400)
 
-    def test_post_add_survey_no_business_raise_ras_error(self):
+    def test_post_add_survey_no_business_raise_Internal_server_error(self):
         self.populate_with_respondent(respondent=self.mock_respondent_with_id)
         db_respondent = respondents()[0]
         token = self.generate_valid_token_from_email(db_respondent.email_address)
@@ -943,7 +945,7 @@ class TestRespondents(PartyTestClient):
             'party_id': self.mock_respondent_with_id['id'],
             'enrolment_code': self.mock_respondent_with_id['enrolment_code']
         }
-        self.add_survey(request_json, 404)
+        self.add_survey(request_json, 500)
 
     def test_put_change_respondent_enrolment_status_disabled_success(self):
         def mock_put_iac(*args, **kwargs):
@@ -1074,5 +1076,32 @@ class TestRespondents(PartyTestClient):
         request_json = {
             'status_change': 'ACTIVE'
         }
-        with patch('ras_party.clients.oauth_client.OauthClient.update_account', return_value=401):
+
+        response = Response()
+        response.status_code = 401
+        with patch('ras_party.clients.oauth_client.OauthClient.update_account', return_value=response):
             self.put_respondent_account_status(request_json, party_id, 500)
+
+    def test_change_respondent_password_bad_auth_response(self):
+        with patch('ras_party.controllers.account_controller.decode_email_token'), \
+             patch('ras_party.controllers.account_controller.current_app'), \
+             patch('ras_party.support.session_decorator.current_app.db'), \
+             patch('ras_party.controllers.account_controller.enrol_respondent_for_survey'), \
+             patch('ras_party.controllers.account_controller.NotifyGateway'), \
+             patch('ras_party.controllers.account_controller.OauthClient') as auth, \
+             patch('ras_party.controllers.account_controller.Requests'):
+            payload = {
+                'new_password': 'password'
+            }
+
+            auth().update_account().status_code.return_value = 500
+            with self.assertRaises(InternalServerError):
+                account_controller.change_respondent_password('token', payload)
+
+    def test_update_verified_email_address_bad_auth_response(self):
+        with patch('ras_party.controllers.account_controller.OauthClient') as auth:
+            respondent = Respondent()
+
+            auth().update_account().status_code.return_value = 500
+            with self.assertRaises(InternalServerError):
+                account_controller.update_verified_email_address(respondent, None, None)

--- a/test/test_session_decorator.py
+++ b/test/test_session_decorator.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import patch, Mock
 
-from ras_party.exceptions import RasError
 from ras_party.support.session_decorator import handle_session
 
 
@@ -27,19 +26,6 @@ class TestSessionDecorator(unittest.TestCase):
         with patch('ras_party.support.session_decorator.current_app') as current_app:
             current_app.db.session.return_value = session_instance
             self.assertRaises(Exception, handle_session, raise_exception, [], {})
-
-            # Then
-            session_instance.rollback.assert_called_once()
-            current_app.db.session.remove.assert_called_once()
-
-    def test_session_decorator_rollback_ras_error(self):
-        # Given
-        def raise_exception(session): raise RasError(None)
-        session_instance = Mock()
-        # When
-        with patch('ras_party.support.session_decorator.current_app') as current_app:
-            current_app.db.session.return_value = session_instance
-            self.assertRaises(RasError, handle_session, raise_exception, [], {})
 
             # Then
             session_instance.rollback.assert_called_once()


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Nearly every exception raised in this service is a 'RasError' or 'ClientError' exception (which is an extension of RasError).
Every RasError raised was logged at error level and with the message 'Uncaught error'.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
I have removed these generic exceptions and replaced them with the appropriate HTTPException.
Logging has also been improved to only have logging at error level when necessary.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ran integration tests
and AT

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/9Fc16htf/279-ras-party-logging-and-exceptions-m