### PR TITLE
Remove unused env var for ras api gateway

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,11 +81,6 @@ class Config(object):
                                                             'confirm_password_change_id')
     RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE = os.getenv('RAS_NOTIFY_ACCOUNT_LOCKED_TEMPLATE', 'account_locked_id')
 
-    RAS_API_GATEWAY_PROTOCOL = os.getenv('RAS_API_GATEWAY_PROTOCOL', 'http')
-    RAS_API_GATEWAY_HOST = os.getenv('RAS_API_GATEWAY_HOST', 'localhost')
-    RAS_API_GATEWAY_PORT = os.getenv('RAS_API_GATEWAY_PORT', 8083)
-    RAS_API_GATEWAY = f'{RAS_API_GATEWAY_PROTOCOL}://{RAS_API_GATEWAY_HOST}:{RAS_API_GATEWAY_PORT}'
-
     RAS_IAC_SERVICE_PROTOCOL = os.getenv('RAS_IAC_SERVICE_PROTOCOL', 'http')
     RAS_IAC_SERVICE_HOST = os.getenv('RAS_IAC_SERVICE_HOST', 'localhost')
     RAS_IAC_SERVICE_PORT = os.getenv('RAS_IAC_SERVICE_PORT', 8121)
@@ -105,7 +100,6 @@ class Config(object):
         'collectionexercise-service',
         'survey-service',
         'notify-service',
-        'api-gateway',
         'iac-service',
         'oauth2-service',
     ]


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There are a number of environment variables that are no longer used. In party these are the environment variables for RAS API Gateway that no longer exists.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
Ran tests and ran up application and checked works as expected with acceptance tests.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
[Trello] https://trello.com/c/v6e0TLEJ
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
