### PR TITLE
Only send case event once for respondent enrolled and no active enrolments

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -148,7 +148,8 @@ def change_respondent_enrolment_status(payload, session):
     # then send NO_ACTIVE_ENROLMENTS case event
     enrolment_count = count_enrolment_by_survey_business(business_id, survey_id, session)
     if not enrolment_count:
-        logger.info("Informing case service of no active enrolments", survey_id=survey_id, business_id=business_id)
+        logger.info("Informing case service of no active enrolments", survey_id=survey_id,
+                    business_id=business_id, respondent_id=respondent.party_uuid)
         post_case_event(case_id=get_case_id_for_business_survey(survey_id, business_id),
                         category='NO_ACTIVE_ENROLMENTS',
                         desc='No active enrolments remaining for case')
@@ -574,7 +575,8 @@ def add_new_survey_for_respondent(payload, tran, session):
     disable_iac(enrolment_code, case_id)
 
     if count_enrolment_by_survey_business(survey_id, business_id, session) == 0:
-        logger.info("Informing case of respondent enrolled", survey_id=survey_id, business_id=business_id)
+        logger.info("Informing case of respondent enrolled", survey_id=survey_id, business_id=business_id,
+                    respondent_id=respondent.party_uuid)
         post_case_event(case_id=case_id, category="RESPONDENT_ENROLED", desc="Respondent enroled")
 
     # This ensures the log message is only written once the DB transaction is committed
@@ -635,7 +637,7 @@ def enrol_respondent_for_survey(respondent, session):
     if count_enrolment_by_survey_business(survey_id=enrolment.survey_id, business_id=enrolment.business_id,
                                           session=session) == 0:
         logger.info("Informing case of respondent enrolled", survey_id=enrolment.survey_id,
-                    business_id=enrolment.business_id)
+                    business_id=enrolment.business_id, respondent_id=respondent.party_uuid)
         post_case_event(case_id=case_id, category="RESPONDENT_ENROLED", desc="Respondent enrolled")
     session.delete(pending_enrolment)
 

--- a/ras_party/controllers/case_controller.py
+++ b/ras_party/controllers/case_controller.py
@@ -1,0 +1,35 @@
+import logging
+import structlog
+
+from flask import current_app
+
+from ras_party.support.requests_wrapper import Requests
+
+logger = structlog.wrap_logger(logging.getLogger(__name__))
+
+
+def post_case_event(case_id, category='Default category message', desc='Default description message'):
+    logger.debug('Posting case event', case_id=case_id)
+    case_svc = current_app.config['RAS_CASE_SERVICE']
+    case_url = f'{case_svc}/cases/{case_id}/events'
+    payload = {
+        'description': desc,
+        'category': category,
+        'createdBy': 'Party Service'
+    }
+
+    response = Requests.post(case_url, json=payload)
+    response.raise_for_status()
+    logger.debug('Successfully posted case event')
+    return response.json()
+
+
+def get_cases_for_casegroup(case_group_id):
+    logger.debug('Requesting cases for case group', casegroup_id=case_group_id)
+    case_svc = current_app.config['RAS_CASE_SERVICE']
+    get_case_url = f'{case_svc}/cases/casegroupid/{case_group_id}'
+
+    response = Requests.get(get_case_url)
+    response.raise_for_status()
+    logger.debug('Successfully retrieved case for case group')
+    return response.json()

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -47,7 +47,9 @@ class MockRequests:
                     'http://mockhost:3333/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87':
                         MockResponse(get_survey_by_id.response),
                     'http://mockhost:6666/iacs/fb747cq725lj':
-                        MockResponse(get_iac.response)
+                        MockResponse(get_iac.response),
+                    'http://mockhost:1111/cases/casegroupid/612f5c34-7e11-4740-8e24-cb321a86a917':
+                        MockResponse(get_cases_by_party.response)
                 }[uri]
             except KeyError:
                 raise Exception(f"MockRequests doesn't know about route {uri}")


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will stop spamming the case service unnecessarily as case will transition all affected cases itself.

# What has changed
<!--- What code changes has been made -->
Remove posting case events for all collection exercises for a survey for a business.
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
Trello https://trello.com/c/vSRfNVCk
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
