### PR TITLE
Change business endpoint to filter enrolments

### DIFF
--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -100,7 +100,7 @@ def get_business_with_respondents_filtered_by_survey(sample_unit_type, id, surve
     return business
 
 
-def filter_enrolments(existing_enrolments, survey_id, enrolment_status):
+def filter_enrolments(existing_enrolments, survey_id, enrolment_status=None):
     filtered_enrolments = []
     for enrolment in existing_enrolments:
         if enrolment['surveyId'] == survey_id:

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -81,7 +81,7 @@ def get_party_by_id(sample_unit_type, id, session):
         raise BadRequest(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']")
 
 
-def get_business_with_respondents_filtered_by_survey(sample_unit_type, id, survey_id):
+def get_business_with_respondents_filtered_by_survey(sample_unit_type, id, survey_id, enrolment_status=None):
     business = get_party_by_id(sample_unit_type, id)
 
     filtered_associations = []
@@ -89,7 +89,7 @@ def get_business_with_respondents_filtered_by_survey(sample_unit_type, id, surve
 
         filtered_association = {'partyId': association['partyId']}
 
-        filtered_enrolments = filter_enrolments(association['enrolments'], survey_id)
+        filtered_enrolments = filter_enrolments(association['enrolments'], survey_id, enrolment_status)
 
         if filtered_enrolments:
             filtered_association['enrolments'] = filtered_enrolments
@@ -100,9 +100,14 @@ def get_business_with_respondents_filtered_by_survey(sample_unit_type, id, surve
     return business
 
 
-def filter_enrolments(existing_enrolments, survey_id):
+def filter_enrolments(existing_enrolments, survey_id, enrolment_status):
     filtered_enrolments = []
     for enrolment in existing_enrolments:
         if enrolment['surveyId'] == survey_id:
             filtered_enrolments.append(enrolment)
+
+    if enrolment_status:
+        for enrolment in filtered_enrolments:
+            if enrolment['enrolmentStatus'] not in enrolment_status:
+                filtered_enrolments.remove(enrolment)
     return filtered_enrolments

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -82,10 +82,10 @@ def get_party_by_id(sample_unit_type, id, session):
 
 
 def get_party_with_enrolments_filtered_by_survey(sample_unit_type, party_id, survey_id, enrolment_status=None):
-    business = get_party_by_id(sample_unit_type, party_id)
+    party = get_party_by_id(sample_unit_type, party_id)
 
     filtered_associations = []
-    for association in business['associations']:
+    for association in party['associations']:
 
         filtered_association = {'partyId': association['partyId']}
 
@@ -95,9 +95,9 @@ def get_party_with_enrolments_filtered_by_survey(sample_unit_type, party_id, sur
             filtered_association['enrolments'] = filtered_enrolments
             filtered_associations.append(filtered_association)
 
-    business['associations'] = filtered_associations
+    party['associations'] = filtered_associations
 
-    return business
+    return party
 
 
 def filter_enrolments(existing_enrolments, survey_id, enrolment_status=None):

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -81,8 +81,8 @@ def get_party_by_id(sample_unit_type, id, session):
         raise BadRequest(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']")
 
 
-def get_business_with_respondents_filtered_by_survey(sample_unit_type, id, survey_id, enrolment_status=None):
-    business = get_party_by_id(sample_unit_type, id)
+def get_party_with_enrolments_filtered_by_survey(sample_unit_type, party_id, survey_id, enrolment_status=None):
+    business = get_party_by_id(sample_unit_type, party_id)
 
     filtered_associations = []
     for association in business['associations']:

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -43,7 +43,7 @@ def get_party_by_id(sample_unit_type, id):
     enrolment_status = request.args.get('enrolment_status')
 
     if survey_id:
-        response = party_controller.get_business_with_respondents_filtered_by_survey(
+        response = party_controller.get_party_with_enrolments_filtered_by_survey(
             sample_unit_type, id, survey_id, enrolment_status)
     else:
         response = party_controller.get_party_by_id(sample_unit_type, id)

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -40,10 +40,11 @@ def get_party_by_ref(sample_unit_type, sample_unit_ref):
 @party_view.route('/parties/type/<sample_unit_type>/id/<id>', methods=['GET'])
 def get_party_by_id(sample_unit_type, id):
     survey_id = request.args.get('survey_id')
+    enrolments = request.args.get('enrolments')
 
     if survey_id:
         response = party_controller.get_business_with_respondents_filtered_by_survey(
-            sample_unit_type, id, survey_id)
+            sample_unit_type, id, survey_id, enrolments)
     else:
         response = party_controller.get_party_by_id(sample_unit_type, id)
 

--- a/ras_party/views/party_view.py
+++ b/ras_party/views/party_view.py
@@ -40,11 +40,11 @@ def get_party_by_ref(sample_unit_type, sample_unit_ref):
 @party_view.route('/parties/type/<sample_unit_type>/id/<id>', methods=['GET'])
 def get_party_by_id(sample_unit_type, id):
     survey_id = request.args.get('survey_id')
-    enrolments = request.args.get('enrolments')
+    enrolment_status = request.args.get('enrolment_status')
 
     if survey_id:
         response = party_controller.get_business_with_respondents_filtered_by_survey(
-            sample_unit_type, id, survey_id, enrolments)
+            sample_unit_type, id, survey_id, enrolment_status)
     else:
         response = party_controller.get_party_by_id(sample_unit_type, id)
 

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -117,12 +117,6 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         return json.loads(response.get_data(as_text=True))
 
-    def get_party_by_id_filtered_by_survey(self, party_type, id, survey_id, expected_status=200):
-        response = self.client.get(f'/party-api/v1/parties/type/{party_type}/id/{id}', data={"survey_id": survey_id},
-                                   headers=self.auth_headers)
-        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
-        return json.loads(response.get_data(as_text=True))
-
     def get_business_by_id(self, id, expected_status=200, query_string=None):
         response = self.client.get(f'/party-api/v1/businesses/id/{id}',
                                    query_string=query_string,
@@ -255,3 +249,11 @@ class PartyTestClient(TestCase):
                                    content_type='application/vnd.ons.business+json')
         self.assertStatus(response, expected_status)
         return response.get_data(as_text=True)
+
+    def get_party_by_id_filtered_by_survey_and_enrolment(self, party_type, id,
+                                                         survey_id, enrolment_statuses, expected_status=200):
+        response = self.client.get(f'/party-api/v1/parties/type/{party_type}/id/{id}?'
+                                   f'survey_id={survey_id}&enrolment_status={enrolment_statuses}',
+                                   headers=self.auth_headers)
+        self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
+        return json.loads(response.get_data(as_text=True))

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -1,9 +1,16 @@
 import uuid
 
+from ras_party.controllers import account_controller
+from ras_party.controllers.queries import query_respondent_by_party_uuid, query_business_by_party_uuid
+from ras_party.models.models import BusinessRespondent, Enrolment, Respondent, RespondentStatus
 from ras_party.support.requests_wrapper import Requests
+from ras_party.support.session_decorator import with_db_session
+from ras_party.support.transactional import transactional
 from test.mocks import MockRequests
 from test.party_client import PartyTestClient, businesses
 from test.test_data.mock_business import MockBusiness
+from test.test_data.mock_respondent import MockRespondent, MockRespondentWithId, MockRespondentWithIdActive
+from test.test_data.mock_enrolment import MockEnrolmentDisabled, MockEnrolmentEnabled, MockEnrolmentPending
 
 
 class TestParties(PartyTestClient):
@@ -11,6 +18,55 @@ class TestParties(PartyTestClient):
     def setUp(self):
         self.mock_requests = MockRequests()
         Requests._lib = self.mock_requests
+        self.mock_respondent = MockRespondent().attributes().as_respondent()
+        self.mock_respondent_with_id = MockRespondentWithId().attributes().as_respondent()
+        self.mock_respondent_with_id_active = MockRespondentWithIdActive().attributes().as_respondent()
+        self.respondent = None
+        self.mock_enrolment_enabled = MockEnrolmentEnabled().attributes().as_enrolment()
+        self.mock_enrolment_disabled = MockEnrolmentDisabled().attributes().as_enrolment()
+        self.mock_enrolment_pending = MockEnrolmentPending().attributes().as_enrolment()
+
+    @transactional
+    @with_db_session
+    def populate_with_respondent(self, tran, session, respondent=None):
+        if not respondent:
+            respondent = self.mock_respondent
+        translated_party = {
+            'party_uuid': respondent.get('id') or str(uuid.uuid4()),
+            'email_address': respondent['emailAddress'],
+            'pending_email_address': respondent.get('pendingEmailAddress'),
+            'first_name': respondent['firstName'],
+            'last_name': respondent['lastName'],
+            'telephone': respondent['telephone'],
+            'status': respondent.get('status') or RespondentStatus.CREATED
+        }
+        self.respondent = Respondent(**translated_party)
+        session.add(self.respondent)
+        account_controller.register_user(respondent, tran)
+        return self.respondent
+
+    @with_db_session
+    def populate_with_enrolment(self, session, enrolment=None):
+        if not enrolment:
+            enrolment = self.mock_enrolment_enabled
+        translated_enrolment = {
+            'business_id': enrolment['business_id'],
+            'respondent_id': enrolment['respondent_id'],
+            'survey_id': enrolment['survey_id'],
+            'status': enrolment['status'],
+            'created_on': enrolment['created_on']
+        }
+        self.enrolment = Enrolment(**translated_enrolment)
+        session.add(self.enrolment)
+
+    @with_db_session
+    def associate_business_and_respondent(self, business_id, respondent_id, session):
+        business = query_business_by_party_uuid(business_id, session)
+        respondent = query_respondent_by_party_uuid(respondent_id, session)
+
+        br = BusinessRespondent(business=business, respondent=respondent)
+
+        session.add(br)
 
     def _make_business_attributes_active(self, mock_business):
         sample_id = mock_business['sampleSummaryId']
@@ -278,6 +334,36 @@ class TestParties(PartyTestClient):
 
     def test_get_party_with_nonexistent_ref(self):
         self.get_party_by_ref('B', '123', 404)
+
+    def test_get_party_by_survey_id_and_enrolment_statuses_with_valid_enrolment(self):
+        self.populate_with_respondent(respondent=self.mock_respondent_with_id)
+        mock_business = MockBusiness() \
+            .attributes(source='test_get_business_by_id_returns_correct_representation') \
+            .as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        self._make_business_attributes_active(mock_business=mock_business)
+        self.associate_business_and_respondent(business_id=mock_business['id'],
+                                               respondent_id=self.mock_respondent_with_id['id'])
+        self.populate_with_enrolment()
+        self.get_party_by_id_filtered_by_survey_and_enrolment('B', mock_business['id'],
+                                                              'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                                                              ['ENABLED', 'PENDING'])
+
+    def test_get_party_by_survey_id_and_enrolment_statuses_with_invalid_enrolment(self):
+        self.populate_with_respondent(respondent=self.mock_respondent_with_id)
+        mock_business = MockBusiness() \
+            .attributes(source='test_get_business_by_id_returns_correct_representation') \
+            .as_business()
+        mock_business['id'] = '3b136c4b-7a14-4904-9e01-13364dd7b972'
+        self.post_to_businesses(mock_business, 200)
+        self._make_business_attributes_active(mock_business=mock_business)
+        self.associate_business_and_respondent(business_id=mock_business['id'],
+                                               respondent_id=self.mock_respondent_with_id['id'])
+        self.populate_with_enrolment(enrolment=self.mock_enrolment_disabled)
+        self.get_party_by_id_filtered_by_survey_and_enrolment('B', mock_business['id'],
+                                                              'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+                                                              ['ENABLED', 'PENDING'])
 
 
 if __name__ == '__main__':

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -336,7 +336,7 @@ class TestParties(PartyTestClient):
         self.get_party_by_ref('B', '123', 404)
 
     def test_get_party_by_survey_id_and_enrolment_statuses_with_valid_enrolment(self):
-        self.populate_with_respondent(respondent=self.mock_respondent_with_id)
+        self.populate_with_respondent(respondent=self.mock_respondent_with_id)  # NOQA
         mock_business = MockBusiness() \
             .attributes(source='test_get_business_by_id_returns_correct_representation') \
             .as_business()
@@ -344,8 +344,8 @@ class TestParties(PartyTestClient):
         self.post_to_businesses(mock_business, 200)
         self._make_business_attributes_active(mock_business=mock_business)
         self.associate_business_and_respondent(business_id=mock_business['id'],
-                                               respondent_id=self.mock_respondent_with_id['id'])
-        self.populate_with_enrolment()
+                                               respondent_id=self.mock_respondent_with_id['id'])  # NOQA
+        self.populate_with_enrolment()  # NOQA
         self.get_party_by_id_filtered_by_survey_and_enrolment('B', mock_business['id'],
                                                               'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                                                               ['ENABLED', 'PENDING'])
@@ -360,7 +360,7 @@ class TestParties(PartyTestClient):
         self._make_business_attributes_active(mock_business=mock_business)
         self.associate_business_and_respondent(business_id=mock_business['id'],
                                                respondent_id=self.mock_respondent_with_id['id'])
-        self.populate_with_enrolment(enrolment=self.mock_enrolment_disabled)
+        self.populate_with_enrolment(enrolment=self.mock_enrolment_disabled)  # NOQA
         self.get_party_by_id_filtered_by_survey_and_enrolment('B', mock_business['id'],
                                                               'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
                                                               ['ENABLED', 'PENDING'])


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to remove logic from action. Action currently has logic to filter enabled and pending enrolments this should live in party.

# What has changed
<!--- What code changes has been made -->
Allow an optional query param to be passed to the get businesses endpoint. Filter enrolments based on passed status.
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
Hit endpoint with postman and ensure provided enrolment status.
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
Trello: https://trello.com/c/kRD5DTTI
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

Action PR: https://github.com/ONSdigital/rm-action-service/pull/104
