### PR TITLE
Changed party_id to string for sending to notify

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -266,9 +266,10 @@ def change_respondent_password(token, payload, tran, session):
         NotifyGateway(current_app.config).request_to_notify(email=email_address,
                                                             template_name='confirm_password_change',
                                                             personalisation=personalisation,
-                                                            reference=party_id)
-    except RasNotifyError:
-        logger.error('Error sending notification email', respondent_id=str(party_id))
+                                                            reference=str(party_id))
+    except RasNotifyError as ras_error:
+        logger.error(ras_error)
+
 
     # This ensures the log message is only written once the DB transaction is committed
     tran.on_success(lambda: logger.info('Respondent has changed their password', respondent_id=party_id))

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -270,7 +270,6 @@ def change_respondent_password(token, payload, tran, session):
     except RasNotifyError as ras_error:
         logger.error(ras_error)
 
-
     # This ensures the log message is only written once the DB transaction is committed
     tran.on_success(lambda: logger.info('Respondent has changed their password', respondent_id=party_id))
 

--- a/ras_party/controllers/notify_gateway.py
+++ b/ras_party/controllers/notify_gateway.py
@@ -51,8 +51,9 @@ class NotifyGateway:
             logger.info('Notification id sent via Notify-Gateway to GOV.UK Notify.', id=response.json()["id"])
 
         except Exception as e:
-            raise RasNotifyError("There was a problem sending a notification via Notify-Gateway to GOV.UK Notify",
-                                 error=e)
+            ref = reference if reference else 'reference_unknown'
+            raise RasNotifyError("There was a problem sending a notification to Notify-Gateway to GOV.UK Notify",
+                                 error=e, reference=ref)
 
     def request_to_notify(self, email, template_name, personalisation=None, reference=None):
         template_id = self._get_template_id(template_name)

--- a/ras_party/exceptions.py
+++ b/ras_party/exceptions.py
@@ -1,5 +1,7 @@
 class RasNotifyError(Exception):
 
-    def __init__(self, description=None, error=None):
+    def __init__(self, description=None, error=None, **kwargs):
         self.description = description
         self.error = error
+        for k,v in kwargs.items():
+            self.__dict__[k] = v

--- a/ras_party/exceptions.py
+++ b/ras_party/exceptions.py
@@ -3,5 +3,5 @@ class RasNotifyError(Exception):
     def __init__(self, description=None, error=None, **kwargs):
         self.description = description
         self.error = error
-        for k,v in kwargs.items():
+        for k, v in kwargs.items():
             self.__dict__[k] = v

--- a/test/test_notify_gateway.py
+++ b/test/test_notify_gateway.py
@@ -53,7 +53,8 @@ class TestNotifyGateway(PartyTestClient):
     def test_notify_exception_is_translated_to_ras_exception(self):
         # Given a mocked gov.uk notify and exception
         def mock_post_notify(*args, **kwargs):
-            return Exception
+            raise Exception("Generic Error")
+
         self.mock_requests.post = mock_post_notify
 
         # When an email is sent

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -504,7 +504,7 @@ class TestRespondents(PartyTestClient):
             email=respondent.email_address,
             template_name='confirm_password_change',
             personalisation=personalisation,
-            reference=uuid.UUID(respondent.party_uuid)
+            reference=respondent.party_uuid
         )
 
     @staticmethod


### PR DESCRIPTION
# Motivation and Context
There was a reported bug whereby some people where not getting their confirmation email after changing passwords. This was traced to a change whereby a uuid instead of a string was attempted to be passed in the json which caused an exception. The exception detail was then swallowed and never made it to the logs .  

# What has changed
now pass a string as party id . Also changed the exception to pass the reference if known , and modified the exception type to handle  name value pairs 

# How to test?
run tests 

# Links
 https://trello.com/c/1GjZ4Cuh
