### PR TITLE
Change Dockerfile to smaller base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.6
-MAINTAINER Joseph Walton
+FROM python:3.6-slim
 
 WORKDIR /app
 COPY . /app
 EXPOSE 8081
-RUN pip3 install pipenv==8.3.1 && pipenv install --deploy --system
+RUN apt-get update -y && apt-get install -y python-pip && apt-get update -y && apt-get install -y curl
+RUN pip3 install pipenv && pipenv install --deploy --system
 
 ENTRYPOINT ["python3"]
 CMD ["run.py"]


### PR DESCRIPTION
# Motivation and Context
Python Docker Images are ~1GB.  This is because of the base image.

# What has changed
Starting using python:3.6-slim instead

# How to test?
System should behave as before, acceptance tests should workfinr

# Links
https://trello.com/c/x0swxIs4/358-tbl358-review-base-docker-images