### PR TITLE
Update packages and fix unit test warnings

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,17 +18,24 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:16505782b229007ae905ef9e0ae6e880fddafa406f086ac7d442c1aaf712f8c2"
+                "sha256:40b9a619aa5f25ea1e1508adcda88b33704ef28e02c9cfa6471e5c772ecf0829"
             ],
             "index": "pypi",
-            "version": "==1.0.7"
+            "version": "==1.0.9"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "cfenv": {
             "hashes": [
@@ -171,57 +178,57 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "jsonschema": {
             "hashes": [
-                "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
-                "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
+                "sha256:0c0a81564f181de3212efa2d17de1910f8732fa1b71c42266d983cd74304e20d",
+                "sha256:a5f6559964a3851f59040d3b961de5e68e70971afb88ba519d27e6a039efff1a"
             ],
             "index": "pypi",
-            "version": "==2.6.0"
+            "version": "==3.0.1"
         },
         "mako": {
             "hashes": [
-                "sha256:4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae"
+                "sha256:0728c404877cd4ca72c409c0ea372dc5f3b53fa1ad2bb434e1d216c0444ff1fd"
             ],
-            "version": "==1.0.7"
+            "version": "==1.0.9"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "orderedmultidict": {
             "hashes": [
@@ -239,46 +246,50 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:19a2d1f3567b30f6c2bb3baea23f74f69d51f0c06c2e2082d0d9c28b0733a4c2",
-                "sha256:2b69cf4b0fa2716fd977aa4e1fd39af6110eb47b2bb30b4e5a469d8fbecfc102",
-                "sha256:2e952fa17ba48cbc2dc063ddeec37d7dc4ea0ef7db0ac1eda8906365a8543f31",
-                "sha256:348b49dd737ff74cfb5e663e18cb069b44c64f77ec0523b5794efafbfa7df0b8",
-                "sha256:3d72a5fdc5f00ca85160915eb9a973cf9a0ab8148f6eda40708bf672c55ac1d1",
-                "sha256:4957452f7868f43f32c090dadb4188e9c74a4687323c87a882e943c2bd4780c3",
-                "sha256:5138cec2ee1e53a671e11cc519505eb08aaaaf390c508f25b09605763d48de4b",
-                "sha256:587098ca4fc46c95736459d171102336af12f0d415b3b865972a79c03f06259f",
-                "sha256:5b79368bcdb1da4a05f931b62760bea0955ee2c81531d8e84625df2defd3f709",
-                "sha256:5cf43807392247d9bc99737160da32d3fa619e0bfd85ba24d1c78db205f472a4",
-                "sha256:676d1a80b1eebc0cacae8dd09b2fde24213173bf65650d22b038c5ed4039f392",
-                "sha256:6b0211ecda389101a7d1d3df2eba0cf7ffbdd2480ca6f1d2257c7bd739e84110",
-                "sha256:79cde4660de6f0bb523c229763bd8ad9a93ac6760b72c369cf1213955c430934",
-                "sha256:7aba9786ac32c2a6d5fb446002ed936b47d5e1f10c466ef7e48f66eb9f9ebe3b",
-                "sha256:7c8159352244e11bdd422226aa17651110b600d175220c451a9acf795e7414e0",
-                "sha256:945f2eedf4fc6b2432697eb90bb98cc467de5147869e57405bfc31fa0b824741",
-                "sha256:96b4e902cde37a7fc6ab306b3ac089a3949e6ce3d824eeca5b19dc0bedb9f6e2",
-                "sha256:9a7bccb1212e63f309eb9fab47b6eaef796f59850f169a25695b248ca1bf681b",
-                "sha256:a3bfcac727538ec11af304b5eccadbac952d4cca1a551a29b8fe554e3ad535dc",
-                "sha256:b19e9f1b85c5d6136f5a0549abdc55dcbd63aba18b4f10d0d063eb65ef2c68b4",
-                "sha256:b664011bb14ca1f2287c17185e222f2098f7b4c857961dbcf9badb28786dbbf4",
-                "sha256:bde7959ef012b628868d69c474ec4920252656d0800835ed999ba5e4f57e3e2e",
-                "sha256:cb095a0657d792c8de9f7c9a0452385a309dfb1bbbb3357d6b1e216353ade6ca",
-                "sha256:d16d42a1b9772152c1fe606f679b2316551f7e1a1ce273e7f808e82a136cdb3d",
-                "sha256:d444b1545430ffc1e7a24ce5a9be122ccd3b135a7b7e695c5862c5aff0b11159",
-                "sha256:d93ccc7bf409ec0a23f2ac70977507e0b8a8d8c54e5ee46109af2f0ec9e411f3",
-                "sha256:df6444f952ca849016902662e1a47abf4fa0678d75f92fd9dd27f20525f809cd",
-                "sha256:e63850d8c52ba2b502662bf3c02603175c2397a9acc756090e444ce49508d41e",
-                "sha256:ec43358c105794bc2b6fd34c68d27f92bea7102393c01889e93f4b6a70975728",
-                "sha256:f4c6926d9c03dadce7a3b378b40d2fea912c1344ef9b29869f984fb3d2a2420b"
+                "sha256:007ca0df127b1862fc010125bc4100b7a630efc6841047bd11afceadb4754611",
+                "sha256:03c49e02adf0b4d68f422fdbd98f7a7c547beb27e99a75ed02298f85cb48406a",
+                "sha256:0a1232cdd314e08848825edda06600455ad2a7adaa463ebfb12ece2d09f3370e",
+                "sha256:131c80d0958c89273d9720b9adf9df1d7600bb3120e16019a7389ab15b079af5",
+                "sha256:2de34cc3b775724623f86617d2601308083176a495f5b2efc2bbb0da154f483a",
+                "sha256:2eddc31500f73544a2a54123d4c4b249c3c711d31e64deddb0890982ea37397a",
+                "sha256:484f6c62bdc166ee0e5be3aa831120423bf399786d1f3b0304526c86180fbc0b",
+                "sha256:4c2d9369ed40b4a44a8ccd6bc3a7db6272b8314812d2d1091f95c4c836d92e06",
+                "sha256:70f570b5fa44413b9f30dbc053d17ef3ce6a4100147a10822f8662e58d473656",
+                "sha256:7a2b5b095f3bd733aab101c89c0e1a3f0dfb4ebdc26f6374805c086ffe29d5b2",
+                "sha256:804914a669186e2843c1f7fbe12b55aad1b36d40a28274abe6027deffad9433d",
+                "sha256:8520c03172da18345d012949a53617a963e0191ccb3c666f23276d5326af27b5",
+                "sha256:90da901fc33ea393fc644607e4a3916b509387e9339ec6ebc7bfded45b7a0ae9",
+                "sha256:a582416ad123291a82c300d1d872bdc4136d69ad0b41d57dc5ca3df7ef8e3088",
+                "sha256:ac8c5e20309f4989c296d62cac20ee456b69c41fd1bc03829e27de23b6fa9dd0",
+                "sha256:b2cf82f55a619879f8557fdaae5cec7a294fac815e0087c4f67026fdf5259844",
+                "sha256:b59d6f8cfca2983d8fdbe457bf95d2192f7b7efdb2b483bf5fa4e8981b04e8b2",
+                "sha256:be08168197021d669b9964bd87628fa88f910b1be31e7010901070f2540c05fd",
+                "sha256:be0f952f1c365061041bad16e27e224e29615d4eb1fb5b7e7760a1d3d12b90b6",
+                "sha256:c1c9a33e46d7c12b9c96cf2d4349d783e3127163fd96254dcd44663cf0a1d438",
+                "sha256:d18c89957ac57dd2a2724ecfe9a759912d776f96ecabba23acb9ecbf5c731035",
+                "sha256:d7e7b0ff21f39433c50397e60bf0995d078802c591ca3b8d99857ea18a7496ee",
+                "sha256:da0929b2bf0d1f365345e5eb940d8713c1d516312e010135b14402e2a3d2404d",
+                "sha256:de24a4962e361c512d3e528ded6c7480eab24c655b8ca1f0b761d3b3650d2f07",
+                "sha256:e45f93ff3f7dae2202248cf413a87aeb330821bf76998b3cf374eda2fc893dd7",
+                "sha256:f046aeae1f7a845041b8661bb7a52449202b6c5d3fb59eb4724e7ca088811904",
+                "sha256:f1dc2b7b2748084b890f5d05b65a47cd03188824890e9a60818721fd492249fb",
+                "sha256:fcbe7cf3a786572b73d2cd5f34ed452a5f5fac47c9c9d1e0642c457a148f9f88"
             ],
             "index": "pypi",
-            "version": "==2.7.7"
+            "version": "==2.8.2"
         },
         "py-zipkin": {
             "hashes": [
-                "sha256:143c12b6d2514c2a20fdec94d5f482a56d6805389bb421cd7ebf1455f7b7d72e",
-                "sha256:a969601a1bd1a04dc0edd3b75a0acc4837b6c22a197b670d7a520713daa12f7c"
+                "sha256:17763f7fe6ba1a4728b9428a412513e5cc59429e70fe9ba9940e54f32f3bd398",
+                "sha256:7bd961c7101be0e9eca6fb2ee11ab6329d8b078862f547e13501cac3771292df"
             ],
-            "version": "==0.18.0"
+            "version": "==0.18.2"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2"
+            ],
+            "version": "==0.14.11"
         },
         "python-dateutil": {
             "hashes": [
@@ -327,10 +338,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:52a42dbf02d0562d6e90e7af59f177f1cc027e72833cc29c3a821eefa009c71d"
+                "sha256:91c54ca8345008fceaec987e10924bf07dcab36c442925357e5a467b36a38319"
             ],
             "index": "pypi",
-            "version": "==1.2.17"
+            "version": "==1.3.3"
         },
         "sqlalchemy-utils": {
             "hashes": [
@@ -349,32 +360,32 @@
         },
         "thriftpy2": {
             "hashes": [
-                "sha256:31a616efb1492ae0caae48006c06d7a7d1f26929c8b4c8a12ec64a99bbd65e87"
+                "sha256:419312421f58e028f8238735f4d99808c7348e5a3f3e7a19e1d9795c98f177ac"
             ],
-            "version": "==0.4.0"
+            "version": "==0.4.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a",
+                "sha256:7fad9770a8778f9576693f0cc29c7dcc36964df916b83734f4431c0e612a7fbc"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.2"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
-                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.5"
         },
         "atomicwrites": {
             "hashes": [
@@ -385,10 +396,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "click": {
             "hashes": [
@@ -399,40 +410,40 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
             ],
             "index": "pypi",
-            "version": "==4.5.2"
+            "version": "==4.5.3"
         },
         "entrypoints": {
             "hashes": [
@@ -450,11 +461,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:c3ba1e130c813191db95c431a18cb4d20a468e98af7a77e2181b68574481ad36",
-                "sha256:fd9ddf503110bf3d8b1d270e8c673aab29ccb3dd6abf29bae1f54e5116ab4a91"
+                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
+                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
             ],
             "index": "pypi",
-            "version": "==3.7.5"
+            "version": "==3.7.7"
         },
         "flask": {
             "hashes": [
@@ -473,11 +484,10 @@
         },
         "isort": {
             "hashes": [
-                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+                "sha256:01cb7e1ca5e6c5b3f235f0385057f70558b70d2f00320208825fa62887292f43",
+                "sha256:268067462aed7eb2a1e237fcb287852f22077de3fb07964e87e00f829eea2d1a"
             ],
-            "version": "==4.3.4"
+            "version": "==4.3.17"
         },
         "itsdangerous": {
             "hashes": [
@@ -489,10 +499,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -530,36 +540,36 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "mccabe": {
             "hashes": [
@@ -570,25 +580,25 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "version": "==7.0.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616",
-                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a"
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
             ],
-            "version": "==0.8.1"
+            "version": "==0.9.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -599,25 +609,25 @@
         },
         "pyflakes": {
             "hashes": [
-                "sha256:5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d",
-                "sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "pylint": {
             "hashes": [
-                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
-                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
             ],
             "index": "pypi",
-            "version": "==2.2.2"
+            "version": "==2.3.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:80cfd9c8b9e93f419abcc0400e9f595974a98e44b6863a77d3e1039961bfc9c4",
-                "sha256:c2396a15726218a2dfef480861c4ba37bd3952ebaaa5b0fede3fc23fddcd7f8c"
+                "sha256:3773f4c235918987d51daf1db66d51c99fac654c81d6f2f709a046ab446d5e5d",
+                "sha256:b7802283b70ca24d7119b32915efa7c409982f59913c1a6c0640aacf118b95f5"
             ],
-            "version": "==4.2.1"
+            "version": "==4.4.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -643,50 +653,51 @@
         },
         "tox": {
             "hashes": [
-                "sha256:04f8f1aa05de8e76d7a266ccd14e0d665d429977cd42123bc38efa9b59964e9e",
-                "sha256:25ef928babe88c71e3ed3af0c464d1160b01fca2dd1870a5bb26c2dea61a17fc"
+                "sha256:1b166b93d2ce66bb7b253ba944d2be89e0c9d432d49eeb9da2988b4902a4684e",
+                "sha256:665cbdd99f5c196dd80d1d8db8c8cf5d48b1ae1f778bccd1bdf14d5aaf4ca0fc"
             ],
             "index": "pypi",
-            "version": "==3.7.0"
+            "version": "==3.9.0"
         },
         "typed-ast": {
             "hashes": [
-                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
-                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
-                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
-                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
-                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
-                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
-                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
-                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
-                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
-                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
-                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
-                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
-                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
-                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
-                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
-                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
-                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
-                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
-                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+                "sha256:04894d268ba6eab7e093d43107869ad49e7b5ef40d1a94243ea49b352061b200",
+                "sha256:16616ece19daddc586e499a3d2f560302c11f122b9c692bc216e821ae32aa0d0",
+                "sha256:252fdae740964b2d3cdfb3f84dcb4d6247a48a6abe2579e8029ab3be3cdc026c",
+                "sha256:2af80a373af123d0b9f44941a46df67ef0ff7a60f95872412a145f4500a7fc99",
+                "sha256:2c88d0a913229a06282b285f42a31e063c3bf9071ff65c5ea4c12acb6977c6a7",
+                "sha256:2ea99c029ebd4b5a308d915cc7fb95b8e1201d60b065450d5d26deb65d3f2bc1",
+                "sha256:3d2e3ab175fc097d2a51c7a0d3fda442f35ebcc93bb1d7bd9b95ad893e44c04d",
+                "sha256:4766dd695548a15ee766927bf883fb90c6ac8321be5a60c141f18628fb7f8da8",
+                "sha256:56b6978798502ef66625a2e0f80cf923da64e328da8bbe16c1ff928c70c873de",
+                "sha256:5cddb6f8bce14325b2863f9d5ac5c51e07b71b462361fd815d1d7706d3a9d682",
+                "sha256:644ee788222d81555af543b70a1098f2025db38eaa99226f3a75a6854924d4db",
+                "sha256:64cf762049fc4775efe6b27161467e76d0ba145862802a65eefc8879086fc6f8",
+                "sha256:68c362848d9fb71d3c3e5f43c09974a0ae319144634e7a47db62f0f2a54a7fa7",
+                "sha256:6c1f3c6f6635e611d58e467bf4371883568f0de9ccc4606f17048142dec14a1f",
+                "sha256:b213d4a02eec4ddf622f4d2fbc539f062af3788d1f332f028a2e19c42da53f15",
+                "sha256:bb27d4e7805a7de0e35bd0cb1411bc85f807968b2b0539597a49a23b00a622ae",
+                "sha256:c9d414512eaa417aadae7758bc118868cd2396b0e6138c1dd4fda96679c079d3",
+                "sha256:f0937165d1e25477b01081c4763d2d9cdc3b18af69cb259dd4f640c9b900fe5e",
+                "sha256:fb96a6e2c11059ecf84e6741a319f93f683e440e341d4489c9b161eca251cf2a",
+                "sha256:fc71d2d6ae56a091a8d94f33ec9d0f2001d1cb1db423d8b4355debfe9ce689b7"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
-            "version": "==1.3.1"
+            "markers": "implementation_name == 'cpython'",
+            "version": "==1.3.4"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:8b9abfc51c38b70f61634bf265e5beacf6fae11fc25d355d1871f49b8e45f0db",
-                "sha256:cceab52aa7d4df1e1871a70236eb2b89fcfe29b6b43510d9738689787c513261"
+                "sha256:15ee248d13e4001a691d9583948ad3947bcb8a289775102e4c4aa98a8b7a6d73",
+                "sha256:bfc98bb9b42a3029ee41b96dc00a34c2f254cbf7716bec824477b2c82741a5c4"
             ],
-            "version": "==16.4.0"
+            "version": "==16.5.0"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a",
+                "sha256:7fad9770a8778f9576693f0cc29c7dcc36964df916b83734f4431c0e612a7fbc"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.2"
         },
         "wrapt": {
             "hashes": [

--- a/alembic.ini
+++ b/alembic.ini
@@ -36,7 +36,7 @@ script_location = migrations
 # output_encoding = utf-8
 
 # this is overridden in env.py file for alembic
-sqlalchemy.url = postgres://postgres:password@localhost:5432/postgres
+sqlalchemy.url = postgresql://postgres:password@localhost:5432/postgres
 
 
 # Logging configuration

--- a/config.py
+++ b/config.py
@@ -38,7 +38,7 @@ class Config(object):
         DATABASE_URI = cf.db.credentials['uri']
     else:
         DATABASE_SCHEMA = os.getenv('DATABASE_SCHEMA', 'partysvc')
-        DATABASE_URI = os.getenv('DATABASE_URI', "postgres://postgres:postgres@localhost:6432/postgres")
+        DATABASE_URI = os.getenv('DATABASE_URI', "postgresql://postgres:postgres@localhost:6432/postgres")
 
     # Zipkin
     ZIPKIN_DISABLE = bool(strtobool(os.getenv("ZIPKIN_DISABLE", "False")))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URI: "postgres://postgres:postgres@db:5432/postgres"
+      DATABASE_URI: "postgresql://postgres:postgres@db:5432/postgres"
     links:
       - db
     ports:

--- a/run.py
+++ b/run.py
@@ -48,8 +48,7 @@ def create_database(db_connection, db_schema, pool_size, max_overflow, pool_recy
     def current_request():
         return _app_ctx_stack.__ident_func__()
 
-    engine = create_engine(db_connection, convert_unicode=True, pool_size=pool_size, max_overflow=max_overflow,
-                           pool_recycle=pool_recycle)
+    engine = create_engine(db_connection, pool_size=pool_size, max_overflow=max_overflow, pool_recycle=pool_recycle)
     session = scoped_session(sessionmaker(), scopefunc=current_request)
     session.configure(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
     # TODO: change this

--- a/test/test_create_database.py
+++ b/test/test_create_database.py
@@ -12,7 +12,7 @@ class TestCreateDatabase(TestCase):
             t.schema = None
 
     def test_postgres_database_schema_exists(self):
-        db_connection = 'postgres://postgres:postgres@localhost:5432/postgres'
+        db_connection = 'postgresql://postgres:postgres@localhost:5432/postgres'
         db_schema = 'partysvc'
 
         with patch('run.create_engine'), patch('run.scoped_session') as upgrade:
@@ -21,7 +21,7 @@ class TestCreateDatabase(TestCase):
         upgrade.assert_called_once()
 
     def test_postgres_database_schema_does_not_exists(self):
-        db_connection = 'postgres://postgres:postgres@localhost:5432/postgres'
+        db_connection = 'postgresql://postgres:postgres@localhost:5432/postgres'
         db_schema = 'partysvc'
 
         with patch('run.create_engine'), patch('run.scoped_session') as session:

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -114,7 +114,7 @@ class TestParties(PartyTestClient):
         self._make_business_attributes_active(mock_business_1)
         self._make_business_attributes_active(mock_business_2)
         response = self.get_businesses_by_ids([party_id_1, party_id_2])
-        self.assertEquals(len(response), 2)
+        self.assertEqual(len(response), 2)
 
         res_dict = {res['id']: res for res in response}
 
@@ -141,7 +141,7 @@ class TestParties(PartyTestClient):
         self._make_business_attributes_active(mock_business_1)
 
         response = self.get_businesses_by_ids([party_id_1, party_id_2, str(uuid.uuid4())])
-        self.assertEquals(len(response), 2)
+        self.assertEqual(len(response), 2)
 
         res_dict = {res['id']: res for res in response}
 
@@ -155,12 +155,12 @@ class TestParties(PartyTestClient):
 
     def test_get_business_by_ids_with_only_an_unknown_id_returns_nothing(self):
         response = self.get_businesses_by_ids([str(uuid.uuid4())])
-        self.assertEquals(len(response), 0)
+        self.assertEqual(len(response), 0)
 
     def test_get_business_by_ids_fails_if_id_is_not_uuid(self):
         party_uuid = "gibberish"
         response = self.get_businesses_by_ids([party_uuid], expected_status=400)
-        self.assertEquals(response['description'], """'gibberish' is not a valid UUID format for property 'id'""")
+        self.assertEqual(response['description'], """'gibberish' is not a valid UUID format for property 'id'""")
 
     def test_get_business_by_id_with_no_active_attributes_returns_404(self):
         mock_business = MockBusiness() \

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -130,7 +130,7 @@ class TestRespondents(PartyTestClient):
         ids = [respondent.party_uuid]
         response = self.get_respondents_by_ids(ids)
         # Then the response matches the posted respondent
-        self.assertEquals(len(response), 1)
+        self.assertEqual(len(response), 1)
         self.assertEqual(response[0]['emailAddress'], self.mock_respondent['emailAddress'])
         self.assertEqual(response[0]['firstName'], self.mock_respondent['firstName'])
         self.assertEqual(response[0]['lastName'], self.mock_respondent['lastName'])
@@ -150,7 +150,7 @@ class TestRespondents(PartyTestClient):
         ids = [respondent_1.party_uuid, respondent_2.party_uuid]
         response = self.get_respondents_by_ids(ids)
 
-        self.assertEquals(len(response), 2)
+        self.assertEqual(len(response), 2)
 
         self.assertTrue('id' in response[0])
 
@@ -171,52 +171,52 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_ids([respondent_1.party_uuid])
 
-        self.assertEquals(len(response), 1)
+        self.assertEqual(len(response), 1)
         self.assertEqual(res_dict[respondent_1.party_uuid]['emailAddress'], 'res1@example.com')
 
     def test_get_respondent_by_ids_with_only_unknown_id_returns_none(self):
         self.populate_with_respondent()
         party_uuid = str(uuid.uuid4())
         response = self.get_respondents_by_ids([party_uuid])
-        self.assertEquals(len(response), 0)
+        self.assertEqual(len(response), 0)
 
     def test_get_respondent_by_ids_fails_if_id_is_not_uuid(self):
         self.populate_with_respondent()
         party_uuid = "gibberish"
         response = self.get_respondents_by_ids([party_uuid], expected_status=400)
-        self.assertEquals(response['description'], """'gibberish' is not a valid UUID format for property 'id'""")
+        self.assertEqual(response['description'], """'gibberish' is not a valid UUID format for property 'id'""")
 
     def test_get_respondents_using_complete_email_returns_respondent(self):
         self.populate_with_respondent()
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="a@z.com",
                                                       expected_status=200)
-        self.assertEquals(response['data'][0]['emailAddress'], 'a@z.com')
+        self.assertEqual(response['data'][0]['emailAddress'], 'a@z.com')
 
     def test_get_respondents_using_partial_in_address_email_returns_respondent(self):
         self.populate_with_respondent()
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="@", expected_status=200)
-        self.assertEquals(response['data'][0]['emailAddress'], 'a@z.com')
+        self.assertEqual(response['data'][0]['emailAddress'], 'a@z.com')
 
     def test_get_respondents_using_partial_starting_address_email_returns_respondent(self):
         self.populate_with_respondent()
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="a", expected_status=200)
-        self.assertEquals(response['data'][0]['emailAddress'], 'a@z.com')
+        self.assertEqual(response['data'][0]['emailAddress'], 'a@z.com')
 
     def test_get_respondents_using_partial_ending_address_email_returns_respondent(self):
         self.populate_with_respondent()
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="m", expected_status=200)
-        self.assertEquals(response['data'][0]['emailAddress'], 'a@z.com')
+        self.assertEqual(response['data'][0]['emailAddress'], 'a@z.com')
 
     def test_get_respondents_using_unknown_address_email_returns_no_respondent(self):
         self.populate_with_respondent()
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="xx@yy.com",
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 0)
+        self.assertEqual(len(response['data']), 0)
 
     def test_get_respondents_using_complete_firstname_returns_respondent(self):
         self.populate_with_respondent()
         response = self.get_respondents_by_name_email(first_name="A", last_name=None, email=None, expected_status=200)
-        self.assertEquals(response['data'][0]['firstName'], 'A')
+        self.assertEqual(response['data'][0]['firstName'], 'A')
 
     def test_get_respondents_using_incorrect_case_complete_firstname_returns_respondent(self):
         mock_respondent = MockRespondent()
@@ -224,7 +224,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name="andrew", last_name=None, email=None,
                                                       expected_status=200)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
 
     def test_get_respondents_using_beginning_of_firstname_returns_respondent(self):
         mock_respondent = MockRespondent()
@@ -232,7 +232,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name="Andr", last_name=None, email=None,
                                                       expected_status=200)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
 
     def test_get_respondents_using_wildcard_in_firstname_returns_respondent(self):
         mock_respondent = MockRespondent()
@@ -240,7 +240,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name="An%ew", last_name=None, email=None,
                                                       expected_status=200)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
 
     def test_get_respondents_using_end_of_firstname_does_not_return_respondent(self):
         mock_respondent = MockRespondent()
@@ -248,12 +248,12 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name="rew", last_name=None, email=None,
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 0)
+        self.assertEqual(len(response['data']), 0)
 
     def test_get_respondents_using_complete_lastname_returns_respondent(self):
         self.populate_with_respondent()
         response = self.get_respondents_by_name_email(first_name=None, last_name="Z", email=None, expected_status=200)
-        self.assertEquals(response['data'][0]['lastName'], 'Z')
+        self.assertEqual(response['data'][0]['lastName'], 'Z')
 
     def test_get_respondents_using_beginning_of_lastname_returns_respondent(self):
         mock_respondent = MockRespondent()
@@ -261,7 +261,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name=None, last_name="Torr", email=None,
                                                       expected_status=200)
-        self.assertEquals(response['data'][0]['lastName'], 'Torrance')
+        self.assertEqual(response['data'][0]['lastName'], 'Torrance')
 
     def test_get_respondents_using_wildcard_in_lastname_returns_respondent(self):
         mock_respondent = MockRespondent()
@@ -269,7 +269,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name=None, last_name="To%ce", email=None,
                                                       expected_status=200)
-        self.assertEquals(response['data'][0]['lastName'], 'Torrance')
+        self.assertEqual(response['data'][0]['lastName'], 'Torrance')
 
     def test_get_respondents_using_beginning_of_lastname_incorrect_case_returns_respondent(self):
         mock_respondent = MockRespondent()
@@ -277,7 +277,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name=None, last_name="ToRr", email=None,
                                                       expected_status=200)
-        self.assertEquals(response['data'][0]['lastName'], 'Torrance')
+        self.assertEqual(response['data'][0]['lastName'], 'Torrance')
 
     def test_get_respondents_using_end_of_lastname_does_not_return_respondent(self):
         mock_respondent = MockRespondent()
@@ -285,7 +285,7 @@ class TestRespondents(PartyTestClient):
         self.populate_with_respondent(respondent=mock_respondent.as_respondent())
         response = self.get_respondents_by_name_email(first_name=None, last_name="nce", email=None,
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 0)
+        self.assertEqual(len(response['data']), 0)
 
     def test_get_respondents_using_first_and_last_name_only_returns_matching_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -300,9 +300,9 @@ class TestRespondents(PartyTestClient):
         response = self.get_respondents_by_name_email(first_name="Andrew", last_name="Tor", email=None,
                                                       expected_status=200)
 
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
-        self.assertEquals(response['data'][0]['lastName'], 'Torrance')
-        self.assertEquals(len(response['data']), 1)
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['lastName'], 'Torrance')
+        self.assertEqual(len(response['data']), 1)
 
     def test_get_respondents_using_matching_first_and_not_matching_last_name_returns_no_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -316,7 +316,7 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name="Andrew", last_name="Williams", email=None,
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 0)
+        self.assertEqual(len(response['data']), 0)
 
     def test_get_respondents_using_matching_email_returns_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -330,9 +330,9 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None,
                                                       email="Andrew.Smith@something.com", expected_status=200)
-        self.assertEquals(len(response['data']), 1)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
-        self.assertEquals(response['data'][0]['lastName'], 'Smith')
+        self.assertEqual(len(response['data']), 1)
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['lastName'], 'Smith')
 
     def test_get_respondents_using_non_matching_email_returns_no_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -346,7 +346,7 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None,
                                                       email="Andrew.Williams@something.com", expected_status=200)
-        self.assertEquals(len(response['data']), 0)
+        self.assertEqual(len(response['data']), 0)
 
     def test_get_respondents_using_matching_email_incorrect_case_returns_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -360,9 +360,9 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None,
                                                       email="AnDREW.SmITH@Something.com", expected_status=200)
-        self.assertEquals(len(response['data']), 1)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
-        self.assertEquals(response['data'][0]['lastName'], 'Smith')
+        self.assertEqual(len(response['data']), 1)
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['lastName'], 'Smith')
 
     def test_get_respondents_using_partial_email_returns_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -376,9 +376,9 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="Smith",
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 1)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
-        self.assertEquals(response['data'][0]['lastName'], 'Smith')
+        self.assertEqual(len(response['data']), 1)
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['lastName'], 'Smith')
 
     def test_get_respondents_using_wildcards_email_returns_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -392,9 +392,9 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="And%Smith",
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 1)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
-        self.assertEquals(response['data'][0]['lastName'], 'Smith')
+        self.assertEqual(len(response['data']), 1)
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['lastName'], 'Smith')
 
     def test_get_respondents_using_non_matching_wildcards_email_does_not_return_respondent(self):
         mock_respondent1 = MockRespondent()
@@ -408,7 +408,7 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="And%Will",
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 0)
+        self.assertEqual(len(response['data']), 0)
 
     def test_get_respondents_using_name_and_email_returns_only_the_respondent_that_match_all_params(self):
         mock_respondent1 = MockRespondent()
@@ -427,9 +427,9 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name="Andrew", last_name="Sm", email="Andrew",
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 1)
-        self.assertEquals(response['data'][0]['firstName'], 'Andrew')
-        self.assertEquals(response['data'][0]['lastName'], 'Smith')
+        self.assertEqual(len(response['data']), 1)
+        self.assertEqual(response['data'][0]['firstName'], 'Andrew')
+        self.assertEqual(response['data'][0]['lastName'], 'Smith')
 
     def test_get_respondents_using_name_and_email_returns_all_respondents_that_match(self):
         mock_respondent1 = MockRespondent()
@@ -447,7 +447,7 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name="Andrew", last_name="%T", email="Andrew",
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 3)
+        self.assertEqual(len(response['data']), 3)
 
     def test_get_respondents_using_name_and_email_returns_respondents_ordered_by_last_name_asc(self):
         mock_respondent1 = MockRespondent()
@@ -465,10 +465,10 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name="Andrew", last_name=None, email="Andrew",
                                                       expected_status=200)
-        self.assertEquals(len(response['data']), 3)
-        self.assertEquals(response['data'][0]['lastName'], 'Alpha')
-        self.assertEquals(response['data'][1]['lastName'], 'Beta')
-        self.assertEquals(response['data'][2]['lastName'], 'Gamma')
+        self.assertEqual(len(response['data']), 3)
+        self.assertEqual(response['data'][0]['lastName'], 'Alpha')
+        self.assertEqual(response['data'][1]['lastName'], 'Beta')
+        self.assertEqual(response['data'][2]['lastName'], 'Gamma')
 
     def test_get_respondents_limit_returns_the_selected_number_of_respondents(self):
         mock_respondent = MockRespondent()
@@ -482,9 +482,9 @@ class TestRespondents(PartyTestClient):
         response = self.get_respondents_by_name_email(first_name="Andrew", last_name=None, email="Andrew",
                                                       page=1, limit=6, expected_status=200)
 
-        self.assertEquals(len(response['data']), 6)
-        self.assertEquals(response['data'][0]['lastName'], 'Torrance_0')
-        self.assertEquals(response['data'][5]['lastName'], 'Torrance_5')
+        self.assertEqual(len(response['data']), 6)
+        self.assertEqual(response['data'][0]['lastName'], 'Torrance_0')
+        self.assertEqual(response['data'][5]['lastName'], 'Torrance_5')
 
     def test_get_respondents_limit_returns_the_available_respondents_if_less_than_limit(self):
         mock_respondent = MockRespondent()
@@ -497,7 +497,7 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name="Andrew", last_name=None, email="Andrew",
                                                       page=1, limit=6, expected_status=200)
-        self.assertEquals(len(response['data']), 3)
+        self.assertEqual(len(response['data']), 3)
 
     def test_get_respondents_page_returns_the_expected_respondents(self):
         respondents_last_name = [f"{chr(i)}_Torrance" for i in range(ord('a'), ord('z') + 1)]
@@ -513,9 +513,9 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="Andrew",
                                                       page=3, limit=6, expected_status=200)
-        self.assertEquals(len(response['data']), 6)
-        self.assertEquals(response['data'][0]['lastName'], 'm_Torrance')
-        self.assertEquals(response['data'][5]['lastName'], 'r_Torrance')
+        self.assertEqual(len(response['data']), 6)
+        self.assertEqual(response['data'][0]['lastName'], 'm_Torrance')
+        self.assertEqual(response['data'][5]['lastName'], 'r_Torrance')
 
     def test_get_respondents_page_returns_remaining_respondents_on_last_page(self):
         respondents_last_name = [f"{chr(i)}_Torrance" for i in range(ord('a'), ord('z') + 1)]
@@ -531,9 +531,9 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="Andrew",
                                                       page=3, limit=12, expected_status=200)
-        self.assertEquals(len(response['data']), 2)
-        self.assertEquals(response['data'][0]['lastName'], 'y_Torrance')
-        self.assertEquals(response['data'][1]['lastName'], 'z_Torrance')
+        self.assertEqual(len(response['data']), 2)
+        self.assertEqual(response['data'][0]['lastName'], 'y_Torrance')
+        self.assertEqual(response['data'][1]['lastName'], 'z_Torrance')
 
     def test_get_respondents_total_represents_total_matching_records(self):
         respondents_last_name = [f"{chr(i)}_Torrance" for i in range(ord('a'), ord('z') + 1)]
@@ -550,8 +550,8 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name="fifthAndrew", last_name=None, email=None,
                                                       page=3, limit=2, expected_status=200)
-        self.assertEquals(len(response['data']), 2)
-        self.assertEquals(response['total'], 6)     # 0, 5, 10, 15, 20 and 25 should be 'fifthAndrew'
+        self.assertEqual(len(response['data']), 2)
+        self.assertEqual(response['total'], 6)     # 0, 5, 10, 15, 20 and 25 should be 'fifthAndrew'
 
     def test_get_respondents_page_returns_zero_respondents_if_none_on_requested_page(self):
         respondents_last_name = [f"{chr(i)}_Torrance" for i in range(ord('a'), ord('z') + 1)]
@@ -567,7 +567,7 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_name_email(first_name=None, last_name=None, email="Andrew",
                                                       page=22, limit=12, expected_status=200)
-        self.assertEquals(len(response['data']), 0)
+        self.assertEqual(len(response['data']), 0)
 
     def test_get_respondent_by_ids_with_an_unknown_id_still_returns_correct_representation_for_other_ids(self):
         respondent_1 = MockRespondent()
@@ -581,7 +581,7 @@ class TestRespondents(PartyTestClient):
 
         response = self.get_respondents_by_ids([respondent_1.party_uuid, respondent_2.party_uuid, str(uuid.uuid4())])
 
-        self.assertEquals(len(response), 2)
+        self.assertEqual(len(response), 2)
 
         self.assertTrue('id' in response[0])
 


### PR DESCRIPTION
# Motivation and Context
There are multiple security issues in packages in this repo.  This PR fixes them.

# What has changed
A number of packages have been upgraded.  Additionally, there have been a few extra changes based on some deprecation warnings provided by the upgraded packages.  These are using the full `postgresql` protocol name for connecting to the database, and removing a `convert_unicode` option that is enabled by default now.

# How to test?
Run the unit and acceptance tests.  They should still pass.

# Links
https://trello.com/c/zF8QeHXz/898-fix-security-warnings-in-party-2