### PR TITLE
Remove configurable name and version from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,33 @@
 # RAS Party
 
 ## Overview
-This is the RAS Party micro-service. See [Confluence] for further information 
+
+This is the RAS Party micro-service. See [Confluence] for further information
 
 The API is specified [here](./API.md)
 
 ## Setup
+
 Install postgresql
+
 ```bash
 brew install postgresql
 ```
 
 Install pipenv
+
 ```bash
 pip install pipenv
 ```
 
 Use pipenv to create a virtualenv and install dependencies
+
 ```bash
 pipenv install
 ```
+
 you can also use the makefile to do this
+
 ```bash
 make install
 ```
@@ -28,33 +35,39 @@ make install
 ## Running
 
 [Install Docker](https://docs.docker.com/engine/installation/)
+
 ```bash
 docker-compose up
 ```
 
 or use the makefile to run
+
 ```bash
 make start
 ```
 
 or run locally (this requires postgres running locally on port 5432):
+
 ```bash
 pipenv run python3 run.py
 ```
 
 To test the service is up:
 
-```
+```bash
 curl http://localhost:8081/info
 ```
 
 ## Tests
+
 Ensure dev dependencies have been installed
+
 ```bash
 pipenv install --dev
 ```
 
 Run tests with tox
+
 ```bash
 pipenv run tox
 ```
@@ -64,7 +77,6 @@ pipenv run tox
 The database will automatically be created when starting the application
 Alembic is used for database migrations
 See [README.md](https://github.com/ONSdigital/ras-party/blob/master/migrations/README.md) for alembic documentation
-
 
 [Confluence]: https://digitaleq.atlassian.net/wiki/display/RASB/Party
 [tox]: https://tox.readthedocs.io/en/latest/

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ requestsdefaulter.default_headers(zipkin.create_http_headers_for_new_span)
 with open(app.config['PARTY_SCHEMA']) as io:
     app.config['PARTY_SCHEMA'] = loads(io.read())
 
-logger_initial_config(service_name='ras-party', log_level=app.config['LOGGING_LEVEL'])
+logger_initial_config(log_level=app.config['LOGGING_LEVEL'])
 
 logger.debug("Created Flask app.")
 

--- a/config.py
+++ b/config.py
@@ -16,9 +16,7 @@ def _is_true(value):
 
 
 class Config(object):
-
-    NAME = os.getenv('RAS-PARTY', 'ras-party')
-    VERSION = os.getenv('VERSION', '1.7.2')
+    VERSION = '1.7.2'
     SCHEME = os.getenv('http')
     HOST = os.getenv('HOST', '0.0.0.0')
     PORT = os.getenv('PORT', 8081)
@@ -26,12 +24,12 @@ class Config(object):
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     SECRET_KEY = os.getenv('SECRET_KEY', 'aardvark')
     EMAIL_TOKEN_SALT = os.getenv('EMAIL_TOKEN_SALT', 'aardvark')
-    EMAIL_TOKEN_EXPIRY = int(os.getenv('EMAIL_TOKEN_EXPIRY', 306000))
+    EMAIL_TOKEN_EXPIRY = int(os.getenv('EMAIL_TOKEN_EXPIRY', '306000'))
     PARTY_SCHEMA = os.getenv('PARTY_SCHEMA', 'ras_party/schemas/party_schema.json')
 
-    DB_POOL_SIZE = int(os.getenv('DB_POOL_SIZE', 5))
-    DB_MAX_OVERFLOW = int(os.getenv('DB_MAX_OVERFLOW', 10))
-    DB_POOL_RECYCLE = int(os.getenv('DB_POOL_RECYCLE', -1))
+    DB_POOL_SIZE = int(os.getenv('DB_POOL_SIZE', '5'))
+    DB_MAX_OVERFLOW = int(os.getenv('DB_MAX_OVERFLOW', '10'))
+    DB_POOL_RECYCLE = int(os.getenv('DB_POOL_RECYCLE', '-1'))
 
     if cf.detected:
         DATABASE_SCHEMA = 'partysvc'
@@ -43,7 +41,7 @@ class Config(object):
     # Zipkin
     ZIPKIN_DISABLE = bool(strtobool(os.getenv("ZIPKIN_DISABLE", "False")))
     ZIPKIN_DSN = os.getenv("ZIPKIN_DSN", None)
-    ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", 0))
+    ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", '0'))
 
     REQUESTS_GET_TIMEOUT = os.getenv('REQUESTS_GET_TIMEOUT', 20)
     REQUESTS_POST_TIMEOUT = os.getenv('REQUESTS_POST_TIMEOUT', 20)

--- a/logger_config.py
+++ b/logger_config.py
@@ -7,24 +7,19 @@ from structlog.processors import JSONRenderer, TimeStamper, format_exc_info
 from structlog.stdlib import add_log_level, filter_by_level
 
 
-def logger_initial_config(service_name=None,
-                          log_level=None,
-                          logger_format=None,
-                          logger_date_format=None):
+def logger_initial_config(log_level=None):
+    """Configures the logger"""
 
-    if not logger_date_format:
-        logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
+    service_name = 'ras-party'
+    logger_format = "%(message)s"
+    logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
+
     if not log_level:
         log_level = os.getenv('LOGGING_LEVEL')
-    if not logger_format:
-        logger_format = "%(message)s"
-    if not service_name:
-        service_name = os.getenv('NAME')
+
     try:
         indent = int(os.getenv('JSON_INDENT_LOGGING'))
-    except TypeError:
-        indent = None
-    except ValueError:
+    except (TypeError, ValueError):
         indent = None
 
     def add_service(logger, method_name, event_dict):  # pylint: disable=unused-argument

--- a/ras_party/controllers/info_controller.py
+++ b/ras_party/controllers/info_controller.py
@@ -13,7 +13,7 @@ if Path('git_info').exists():
 
 def get_info():
     info = {
-        "name": current_app.config['NAME'],
+        "name": 'ras-party',
         "version": current_app.config['VERSION'],
     }
     info = dict(_health_check, **info)

--- a/run.py
+++ b/run.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     with open(app.config['PARTY_SCHEMA']) as io:
         app.config['PARTY_SCHEMA'] = loads(io.read())
 
-    logger_initial_config(service_name='ras-party', log_level=app.config['LOGGING_LEVEL'])
+    logger_initial_config(log_level=app.config['LOGGING_LEVEL'])
 
     try:
         initialise_db(app)

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -39,7 +39,7 @@ class PartyTestClient(TestCase):
     @staticmethod
     def create_app():
         app = create_app('TestingConfig')
-        logger_initial_config(service_name='ras-party', log_level=app.config['LOGGING_LEVEL'])
+        logger_initial_config(log_level=app.config['LOGGING_LEVEL'])
         app.config['PARTY_SCHEMA'] = party_schema.schema
         app.db = create_database(app.config['DATABASE_URI'], app.config['DATABASE_SCHEMA'], app.config['DB_POOL_SIZE'],
                                  app.config['DB_MAX_OVERFLOW'], app.config['DB_POOL_RECYCLE'])


### PR DESCRIPTION
# Motivation and Context
This application has a configurable name and version. These aren't things that should be configured on deploy.

# What has changed
The single use of NAME is now hardcoded in the info endpoint and logging configuration. The configurable version is now hardcoded in the config file. Updated the readme to show all the configurable items. The readme has also had its linting issues fixed.

There were pylint errors with os.getenv having a non string or None value as the default.  I changed the ones that would definitely not break (as they were immediately being converted to an int, so the result was always going to be the same).  There are other ones that need tidying up, but I don't want to do it as part of this PR

# How to test?
- Unit tests pass
- Check preprod and prod deployment to make sure NAME and VERSION aren't being set. If they are, remove them.

# Links
https://trello.com/c/rao67UDS/1011-remove-application-name-config-item-environment-variable-from-ras-repos-3
