### PR TITLE
Added rollbacks and the use of sub transactions

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -106,8 +106,8 @@ def post_respondent(party, session):
 def _add_enrolment_and_auth(business, business_id, case_id, party, session, survey_id, translated_party):
     """Create and persist new party entities and attempt to register with auth service.
     Auth fails lead to party entities being rolled back.
+    The Contxet manager commits to session, If db fails after that and before main commit then db state is unknown
     """
-    session.begin_nested()  # Create a transaction SAVEPOINT
     try:
         with session.begin_nested():
 
@@ -143,7 +143,6 @@ def _add_enrolment_and_auth(business, business_id, case_id, party, session, surv
             session.rollback()  # Rollback to SAVEPOINT
             oauth_response.raise_for_status()
 
-        session.commit()  # Commits to sub transaction
         session.commit()  # Full session commit
 
     logger.info("New user has been registered via the auth-service")

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -33,13 +33,11 @@ NO_RESPONDENT_FOR_PARTY_ID = 'There is no respondent with that party ID '
 EMAIL_VERIFICATION_SENT = 'A new verification email has been sent'
 
 
-@transactional
 @with_db_session
-def post_respondent(party, tran, session):
+def post_respondent(party, session):
     """
     Register respondent and set up pending enrolment before account verification
     :param party: respondent to be created details
-    :param tran
     :param session
     :return: created respondent
     """
@@ -95,24 +93,61 @@ def post_respondent(party, tran, session):
         'status': RespondentStatus.CREATED
     }
 
-    #  Create the enrolment respondent-business-survey associations
-    respondent = Respondent(**translated_party)
-    br = BusinessRespondent(business=business, respondent=respondent)
-    pending_enrolment = PendingEnrolment(case_id=case_id,
-                                         respondent=respondent,
-                                         business_id=business_id,
-                                         survey_id=survey_id)
-    Enrolment(business_respondent=br,
-              survey_id=survey_id,
-              status=EnrolmentStatus.PENDING)
-    session.add(respondent)
-    session.add(pending_enrolment)
-    session.commit()
+    respondent = _try_commit_party_and_auth(business, business_id, case_id, party, session, survey_id,
+                                            translated_party)
+
+    disable_iac(party['enrolmentCode'], case_id)  # calls raise for status
+
     _send_email_verification(respondent.party_uuid, party['emailAddress'])
 
-    register_user(party, tran)
-    disable_iac(party['enrolmentCode'], case_id)
     return respondent.to_respondent_dict()
+
+
+def _try_commit_party_and_auth(business, business_id, case_id, party, session, survey_id, translated_party):
+    """Create and persist new party entities and attempt to register with auth service.
+    Auth fails lead to party entities being rolled back.
+    """
+    session.begin_nested()  # Create a transaction SAVEPOINT
+    try:
+        with session.begin_nested():
+
+            # Use a sub transaction to store party data
+            # Context manager will manage commits/rollback
+
+            # Create the enrolment respondent-business-survey associations
+
+            respondent = Respondent(**translated_party)
+            br = BusinessRespondent(business=business, respondent=respondent)
+            pending_enrolment = PendingEnrolment(case_id=case_id,
+                                                 respondent=respondent,
+                                                 business_id=business_id,
+                                                 survey_id=survey_id)
+            Enrolment(business_respondent=br,
+                      survey_id=survey_id,
+                      status=EnrolmentStatus.PENDING)
+
+            session.add(respondent)
+            session.add(pending_enrolment)
+
+    except Exception as exception:
+        logger.error('Party service db post respondent caused exception', party_uuid=translated_party['party_uuid'],
+                     error=exception)
+        raise  # re raise the exception aimed at the generic handler
+    else:
+        # Register user to auth server after successful commit
+        oauth_response = OauthClient().create_account(party['emailAddress'], party['password'])
+        if not oauth_response.status_code == 201:
+            logger.info('Registering respondent auth service responded with', status=oauth_response.status_code,
+                        content=oauth_response.content)
+
+            session.rollback()  # Rollback to SAVEPOINT
+            oauth_response.raise_for_status()
+
+        session.commit()  # Commits to sub transaction
+        session.commit()  # Full session commit
+
+    logger.info("New user has been registered via the auth-service")
+    return respondent
 
 
 @with_db_session
@@ -642,7 +677,7 @@ def enrol_respondent_for_survey(respondent, session):
     session.delete(pending_enrolment)
 
 
-def register_user(party, tran):
+def register_user(party):
     oauth_response = OauthClient().create_account(
         party['emailAddress'], party['password'])
     if not oauth_response.status_code == 201:
@@ -650,13 +685,6 @@ def register_user(party, tran):
                     content=oauth_response.content)
         oauth_response.raise_for_status()
 
-    def dummy_compensating_action():
-        # TODO: Undo the user registration.
-
-        logger.info("Placeholder for deleting the user from oauth server")
-
-    # Add a compensating action to try and avoid an exception leaving the user in an invalid state.
-    tran.compensate(dummy_compensating_action)
     logger.info("New user has been registered via the oauth2-service")
 
 

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -93,8 +93,8 @@ def post_respondent(party, session):
         'status': RespondentStatus.CREATED
     }
 
-    respondent = _try_commit_party_and_auth(business, business_id, case_id, party, session, survey_id,
-                                            translated_party)
+    respondent = _add_enrolment_and_auth(business, business_id, case_id, party, session, survey_id,
+                                         translated_party)
 
     disable_iac(party['enrolmentCode'], case_id)  # calls raise for status
 
@@ -103,7 +103,7 @@ def post_respondent(party, session):
     return respondent.to_respondent_dict()
 
 
-def _try_commit_party_and_auth(business, business_id, case_id, party, session, survey_id, translated_party):
+def _add_enrolment_and_auth(business, business_id, case_id, party, session, survey_id, translated_party):
     """Create and persist new party entities and attempt to register with auth service.
     Auth fails lead to party entities being rolled back.
     """

--- a/test/test_party_controller.py
+++ b/test/test_party_controller.py
@@ -5,7 +5,6 @@ from ras_party.controllers.queries import query_respondent_by_party_uuid, query_
 from ras_party.models.models import BusinessRespondent, Enrolment, Respondent, RespondentStatus
 from ras_party.support.requests_wrapper import Requests
 from ras_party.support.session_decorator import with_db_session
-from ras_party.support.transactional import transactional
 from test.mocks import MockRequests
 from test.party_client import PartyTestClient, businesses
 from test.test_data.mock_business import MockBusiness
@@ -27,9 +26,8 @@ class TestParties(PartyTestClient):
         self.mock_enrolment_disabled = MockEnrolmentDisabled().attributes().as_enrolment()
         self.mock_enrolment_pending = MockEnrolmentPending().attributes().as_enrolment()
 
-    @transactional
     @with_db_session
-    def populate_with_respondent(self, tran, session, respondent=None):
+    def populate_with_respondent(self, session, respondent=None):
         if not respondent:
             respondent = self.mock_respondent
         translated_party = {
@@ -43,7 +41,7 @@ class TestParties(PartyTestClient):
         }
         self.respondent = Respondent(**translated_party)
         session.add(self.respondent)
-        account_controller.register_user(respondent, tran)
+        account_controller.register_user(respondent)
         return self.respondent
 
     @with_db_session


### PR DESCRIPTION
# Motivation and Context
If auth registration failed on add new user then the records where left in the party service.
Added sub transactions so that roll back can be added on auth registration fail

# What has changed
removed @transaction , this was an app level transaction not db transaction and was not used
Added sub transactions so that we can roll back to specific points

# How to test?
run unit and acceptance tests . A difficult one to test manually.

# Links
https://trello.com/c/UtaGbEk1