### PR TITLE
Improve logging around email verification

### DIFF
--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -357,7 +357,7 @@ def resend_password_email_expired_token(token, session):
     :param session: database session
     :return: response
     """
-    email_address = decode_email_token(token, duration=None)
+    email_address = decode_email_token(token)
     respondent = query_respondent_by_email(email_address, session)
 
     if not respondent:
@@ -521,13 +521,15 @@ def resend_verification_email_by_uuid(party_uuid, session):
     :return: response
 
     """
-    logger.info('Attempting to resend verification_email', party_uuid=party_uuid)
+    logger.info('Attempting to resend verification email', party_uuid=party_uuid)
 
     respondent = query_respondent_by_party_uuid(party_uuid, session)
     if not respondent:
+        logger.info(NO_RESPONDENT_FOR_PARTY_ID, party_uuid=party_uuid)
         raise NotFound(NO_RESPONDENT_FOR_PARTY_ID)
 
     response = _resend_verification_email(respondent)
+    logger.info('Verification email successfully resent', party_uuid=party_uuid)
     return response
 
 
@@ -539,14 +541,16 @@ def resend_verification_email_expired_token(token, session):
     :param session: database session
     :return: response
     """
-    email_address = decode_email_token(token, duration=None)
+    logger.info('Attempting to resend verification email with expired token', token=token)
+    email_address = decode_email_token(token)
     respondent = query_respondent_by_email(email_address, session)
 
     if not respondent:
-        logger.info("Respondent does not exist")
+        logger.info("Respondent does not exist", token=token)
         raise NotFound("Respondent does not exist")
 
     response = _resend_verification_email(respondent)
+    logger.info('Successfully resent verification email with expired token', token=token)
     return response
 
 

--- a/ras_party/support/verification.py
+++ b/ras_party/support/verification.py
@@ -10,6 +10,11 @@ logger = structlog.wrap_logger(logging.getLogger(__name__))
 
 
 def generate_email_token(email):
+    """Creates a token based on a provided email address
+
+    :param email: email address of the respondent
+    :return: A serialised string containing the email address
+    """
     secret_key = current_app.config["SECRET_KEY"]
     email_token_salt = current_app.config["EMAIL_TOKEN_SALT"]
 
@@ -23,10 +28,19 @@ def generate_email_token(email):
     return timed_serializer.dumps(email, salt=email_token_salt)
 
 
-def decode_email_token(token, duration):
-    logger.info('Checking email verification token', token=token)
+def decode_email_token(token, duration=None):
+    """Decodes a token and returns the result
+
+    :param token: A serialised string
+    :param duration: The amount of time in seconds the token is valid for.  If the token is older
+    then this number, an exception will be thrown. Default is None.
+    :return: The contents of the deserialised token
+    """
+    logger.info('Decoding email verification token', token=token)
 
     timed_serializer = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
     email_token_salt = current_app.config["EMAIL_TOKEN_SALT"]
 
-    return timed_serializer.loads(token, salt=email_token_salt, max_age=duration)
+    result = timed_serializer.loads(token, salt=email_token_salt, max_age=duration)
+    logger.info('Successfully decoded email verification token', token=token)
+    return result

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -290,5 +290,5 @@ class PartyTestClient(TestCase):
         self.assertStatus(response, expected_status, "Response body is : " + response.get_data(as_text=True))
         response_data = response.get_data().decode("utf-8")
         if expected_result:
-            self.assertEquals(response_data, expected_result)
+            self.assertEqual(response_data, expected_result)
         return response_data


### PR DESCRIPTION
# Motivation and Context
Whilst trying to figure out what went wrong during an email verification issue, it was noted that the logging around is was fairly bad.  This PR improves it.

# What has changed
- Improves logging around email verification
- Added docstrings to a few functions around tokens
- Fixed deprecation warning in a few of the unit tests

# How to test?
Unit and acceptance tests pass

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
