### PR TITLE
Replace delete by id with delete by email

### DIFF
--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -98,11 +98,22 @@ def query_respondent_by_party_uuid(party_uuid, session):
 def query_respondent_by_email(email, session):
     """
     Query to return respondent based on email
-    :param email: the party uuid
+    :param email: the party email
     :return: respondent or none
     """
     logger.info('Querying respondents by email')
     return session.query(Respondent).filter(func.lower(Respondent.email_address) == email.lower()).first()
+
+
+def query_single_respondent_by_email(email, session):
+    """
+    Query to return respondent based on email.  Must only return 1 result, otherwise it will throw either
+    a NoResultFound or MultipleResultsFound exceptions.
+    :param email: the party email
+    :return: single respondent or exception thrown
+    """
+    logger.info('Querying respondents by email, expecting exactly one result')
+    return session.query(Respondent).filter(func.lower(Respondent.email_address) == email.lower()).one()
 
 
 def query_respondent_by_pending_email(email, session):

--- a/ras_party/support/util.py
+++ b/ras_party/support/util.py
@@ -58,3 +58,13 @@ def flatten_keys(d, prefix=None):
 def build_url(template, config, *args):
     url = template.format(config['scheme'], config['host'], config['port'], *args)
     return url
+
+
+def obfuscate_email(email):
+    """Takes an email address and returns an obfuscated version of it.
+    For example: test@example.com would turn into t**t@e*********m
+    """
+    m = email.split('@')
+    prefix = f'{m[0][0]}{"*"*(len(m[0])-2)}{m[0][-1]}'
+    domain = f'{m[1][0]}{"*"*(len(m[1])-2)}{m[1][-1]}'
+    return f'{prefix}@{domain}'

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -85,18 +85,28 @@ def get_respondent_by_id(respondent_id):
     return jsonify(response)
 
 
-@respondent_view.route('/respondents/id/<party_uuid>', methods=['DELETE'])
-def delete_respondent_by_id(party_uuid):
-    respondent_controller.delete_respondent_by_id(party_uuid)
-    return '', 204
-
-
 @respondent_view.route('/respondents/email', methods=['GET'])
 def get_respondent_by_email():
     payload = request.get_json()
     email = payload['email']
     response = respondent_controller.get_respondent_by_email(email)
     return jsonify(response)
+
+
+@respondent_view.route('/respondents/email', methods=['DELETE'])
+def delete_respondent_by_email():
+    try:
+        email = request.get_json()['email']
+    except TypeError:
+        raise BadRequest('JSON payload not provided')
+    except KeyError:
+        raise BadRequest("Email key must be provided in the JSON payload")
+
+    if not email:
+        raise BadRequest("Email cannot be empty")
+
+    respondent_controller.delete_respondent_by_email(email)
+    return '', 204
 
 
 @respondent_view.route('/respondents/id/<respondent_id>', methods=['PUT'])


### PR DESCRIPTION
# Motivation and Context
The original delete respodent in party did it by ID.  This is tricky because the auth service can only do it by email.  By doing the delete by email, the script to actually delete a user becomes much simpler as we only need 1 thing (the users email) rather then having to take an email and resolve it to a party_uuid before being able to do anything.

# What has changed
Added a DELETE /respondents/email endpoint
Removed the DELETE /respondents/id/uuid endpoint

# How to test?
- Seed the party database with the acceptance tests.
- Find a user to delete
- Hit the endpoint with that email.  It should fail.

- Additionally, try and hit it with empty json, json with a blank email address and with content that isn't json.  All of these should throw 400 errors.


# Links
https://trello.com/c/GzZO9UbF
