### PR TITLE
Remove error on not found

### DIFF
--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -10,7 +10,7 @@ from ras_party.models.models import Enrolment, BusinessRespondent, PendingEnrolm
 from ras_party.controllers.queries import query_respondent_by_party_uuid, \
     query_respondent_by_email, update_respondent_details, query_respondent_by_names_and_emails, \
     query_respondent_by_party_uuids, query_single_respondent_by_email
-from ras_party.support.session_decorator import with_db_session
+from ras_party.support.session_decorator import with_db_session, with_query_only_db_session
 from ras_party.support.util import obfuscate_email
 
 
@@ -108,7 +108,7 @@ def delete_respondent_by_email(email, session):
                 id=respondent.id)
 
 
-@with_db_session
+@with_query_only_db_session
 def get_respondent_by_email(email, session):
     """
     Get a verified respondent by its email address.


### PR DESCRIPTION
# Motivation and Context
We're getting a lot of alerts around exceptions being raised.  This is because a NotFound exception (which is totally fine) is being caught by the with_db_session wrapper, logging an exception and rolling back the database (not fine if all we've done is see if a user exists..)

# What has changed
New with_query_only_db_session wrapper added that is only meant to be used with database calls that only affect the database.

# How to test?
- Unit and acceptance tests pass
- On master, try and sign in with a user that doesn't exist.  Then try one that does exist.  The former should raise a logger.exception line in ras-party.  Switch to this branch and try it again.  Both should be the same to the user but ras-party won't log an exception line (as nothing is wrong!!11)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
