### PR TITLE
Fix stack traces being split over multiple lines

### DIFF
--- a/ras_party/support/session_decorator.py
+++ b/ras_party/support/session_decorator.py
@@ -21,19 +21,21 @@ def handle_session(f, args, kwargs):
         session.commit()
         return result
     except SQLAlchemyError as exc:
-        logger.exception(f"Rolling back database session due to {exc.__class__.__name__}",
-                         pool_size=current_app.db.engine.pool.size(),
-                         connections_in_pool=current_app.db.engine.pool.checkedin(),
-                         connections_checked_out=current_app.db.engine.pool.checkedout(),
-                         current_overflow=current_app.db.engine.pool.overflow())
+        logger.error(f"Rolling back database session due to {exc.__class__.__name__}",
+                     pool_size=current_app.db.engine.pool.size(),
+                     connections_in_pool=current_app.db.engine.pool.checkedin(),
+                     connections_checked_out=current_app.db.engine.pool.checkedout(),
+                     current_overflow=current_app.db.engine.pool.overflow(),
+                     exc_info=True)
         session.rollback()
         raise SQLAlchemyError(f"{exc.__class__.__name__} occurred when committing to database", code=exc.code)
     except Exception:
-        logger.exception("Rolling back database session due to uncaught exception",
-                         pool_size=current_app.db.engine.pool.size(),
-                         connections_in_pool=current_app.db.engine.pool.checkedin(),
-                         connections_checked_out=current_app.db.engine.pool.checkedout(),
-                         current_overflow=current_app.db.engine.pool.overflow())
+        logger.error("Rolling back database session due to uncaught exception",
+                     pool_size=current_app.db.engine.pool.size(),
+                     connections_in_pool=current_app.db.engine.pool.checkedin(),
+                     connections_checked_out=current_app.db.engine.pool.checkedout(),
+                     current_overflow=current_app.db.engine.pool.overflow(),
+                     exc_info=True)
         session.rollback()
         raise
     finally:
@@ -47,11 +49,12 @@ def handle_query_only_session(f, args, kwargs):
         result = f(*args, session=session, **kwargs)
         return result
     except SQLAlchemyError:
-        logger.exception("Something went wrong accessing database",
-                         pool_size=current_app.db.engine.pool.size(),
-                         connections_in_pool=current_app.db.engine.pool.checkedin(),
-                         connections_checked_out=current_app.db.engine.pool.checkedout(),
-                         current_overflow=current_app.db.engine.pool.overflow())
+        logger.error("Something went wrong accessing database",
+                     pool_size=current_app.db.engine.pool.size(),
+                     connections_in_pool=current_app.db.engine.pool.checkedin(),
+                     connections_checked_out=current_app.db.engine.pool.checkedout(),
+                     current_overflow=current_app.db.engine.pool.overflow(),
+                     exc_info=True)
         raise
     finally:
         current_app.db.session.remove()


### PR DESCRIPTION
# Motivation and Context
A number of exceptions were causing stack traces to be logged out over mulitiple individual lines in splunk (instead of being a field containing a stacktrace string as a value).  This was making it difficult to read the logs in splunk as an exception would generate 8+ lines (where each line consisted of 12+ bits of metadata).

# What has changed
The logging in the wrapper now uses `exc_info` true to include an `exception` key, with the stacktrace as a string (with newlines that splunk will render correctly)

# How to test?
On master, go to frontstage and click forgot password.  Put a junk email in there.  You'll notice teh logging look something like 
```
{"event": "Respondent does not exist", "level": "info", "service": "ras-party", "created_at": "2019-11-07T15:161573139791"}
{"pool_size": 5, "connections_in_pool": 0, "connections_checked_out": 2, "current_overflow": -3, "event": "Rolling back database session due to uncaught exception", "level": "exception", "service": "ras-party", "created_at": "2019-11-07T15:161573139791"}
Traceback (most recent call last):
  File "/app/ras_party/support/session_decorator.py", line 19, in handle_session
    result = f(*args, session=session, **kwargs)
  File "/app/ras_party/controllers/account_controller.py", line 321, in request_password_change
    raise NotFound("Respondent does not exist")
werkzeug.exceptions.NotFound: 404 Not Found: Respondent does not exist
172.19.0.21 - - [07/Nov/2019 15:16:31] "POST /party-api/v1/respondents/request_password_change HTTP/1.1" 404 -
```

Switch to this branch and do the same thing, the logging should look like:
```
{"event": "Respondent does not exist", "level": "info", "service": "ras-party", "created_at": "2019-11-07T15:361573141010"}
{"pool_size": 5, "connections_in_pool": 0, "connections_checked_out": 2, "current_overflow": -3, "event": "Rolling back database session due to uncaught exception", "level": "error", "service": "ras-party", "exception": "Traceback (most recent call last):\n  File \"/Users/manna/projects/ras/ras-party/ras_party/support/session_decorator.py\", line 20, in handle_session\n    result = f(*args, session=session, **kwargs)\n  File \"/Users/manna/projects/ras/ras-party/ras_party/controllers/account_controller.py\", line 321, in request_password_change\n    raise NotFound(\"Respondent does not exist\")\nwerkzeug.exceptions.NotFound: 404 Not Found: Respondent does not exist", "created_at": "2019-11-07T15:361573141010"}
127.0.0.1 - - [07/Nov/2019 15:36:50] "POST /party-api/v1/respondents/request_password_change HTTP/1.1" 404 -
```

# Links
https://trello.com/c/etLDBbdz
