### PR TITLE
Add quiet db wrapper

### DIFF
--- a/ras_party/controllers/iac_controller.py
+++ b/ras_party/controllers/iac_controller.py
@@ -19,6 +19,13 @@ def request_iac(enrolment_code):
 
 
 def disable_iac(enrolment_code, case_id):
+    """
+    Disables the iac code by calling the iac service
+    :param enrolment_code: A string containing the code to disable
+    :param case_id: A string containing a uuid for the case
+    :returns:  A dictionary containing the json response from the call
+    :raises ValueError:  Raised when the response doesn't return json (on a 500 response?)
+    """
     iac_svc = current_app.config['IAC_SERVICE']
     iac_url = f'{iac_svc}/iacs/{enrolment_code}'
     payload = {
@@ -28,5 +35,10 @@ def disable_iac(enrolment_code, case_id):
     try:
         response.raise_for_status()
     except requests.HTTPError:
+        # Needs to be investigated by someone with more time, do we swallow the HTTPError because the
+        # response.json line below will probably throw a ValueError?  If it's a 404 then it's assumed that
+        # it returns a json message saying it's not found.  Or is the idea to not interrupt the users
+        # journey and we can just handle it ourselves after the fact?
         logger.error("IAC failed to be disabled", case_id=case_id)
+
     return response.json()


### PR DESCRIPTION
# Motivation and Context
The @with_db_session wrapper logs an exception when an exception is thrown.  Not all exceptions are bad (we raise BadRequest and other HTTPErrors to simplify returning error statuses).  This is the first attempt to write a new wrapper (which we will eventually convert everything to) that handles the SQLAlchemyErrors for you but other exceptions you have to handle yourself.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
- When creating an account, make sure it still works.
- Not sure how to test the other error states...

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
