### PR TITLE
Add DNS entries to Helm config

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -115,16 +115,12 @@ spec:
           - name: FRONTSTAGE_HOST
             {{- if .Values.email.enabled }}
             value: {{ .Values.email.callback.host }}
-            {{- else if .Values.dns.enabled }}
-            value: "frontstage.{{ .Values.namespace }}.svc.cluster.local"
             {{- else }}
             value: "$(FRONTSTAGE_SERVICE_HOST)"
             {{- end }}
           - name: FRONTSTAGE_PORT
             {{- if .Values.email.enabled }}
             value: "{{ .Values.email.callback.port }}"
-            {{- else if .Values.dns.enabled }}
-            value: "{{ .Values.dns.wellKnownPort }}"
             {{- else }}
             value: "$(FRONTSTAGE_SERVICE_PORT)"
             {{- end }}

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -115,12 +115,16 @@ spec:
           - name: FRONTSTAGE_HOST
             {{- if .Values.email.enabled }}
             value: {{ .Values.email.callback.host }}
+            {{- else if .Values.dns.enabled }}
+            value: "frontstage.{{ .Values.namespace }}.svc.cluster.local"
             {{- else }}
             value: "$(FRONTSTAGE_SERVICE_HOST)"
             {{- end }}
           - name: FRONTSTAGE_PORT
             {{- if .Values.email.enabled }}
             value: "{{ .Values.email.callback.port }}"
+            {{- else if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
             {{- else }}
             value: "$(FRONTSTAGE_SERVICE_PORT)"
             {{- end }}
@@ -152,8 +156,20 @@ spec:
               secretKeyRef:
                 name: oauth-secret
                 key: oauth-client-secret
+          - name: NOTIFY_SERVICE_HOST
+            {{- if .Values.dns.enabled }}
+            value: "notify-gateway.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
+            value: "$(NOTIFY_GATEWAY_SERVICE_HOST)"
+            {{- end }}
+          - name: NOTIFY_SERVICE_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: $(NOTIFY_GATEWAY_SERVICE_PORT)
+            {{- end }}
           - name: NOTIFY_SERVICE_URL
-            value: "http://$(NOTIFY_GATEWAY_SERVICE_HOST):$(NOTIFY_GATEWAY_SERVICE_PORT)/emails/"
+            value: "http://$(NOTIFY_SERVICE_HOST):$(NOTIFY_SERVICE_PORT)/emails/"
           - name: NOTIFY_EMAIL_VERIFICATION_TEMPLATE
             value: "{{ .Values.email.templates.notifyEmailVerificationTemplate }}"
           - name: NOTIFY_CONFIRM_PASSWORD_CHANGE_TEMPLATE
@@ -163,9 +179,17 @@ spec:
           - name: NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE
             value: "{{ .Values.email.templates.notifyRequestPasswordChangeTemplate }}"
           - name: OAUTH_SERVICE_HOST
+            {{- if .Values.dns.enabled }}
+            value: "auth.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(AUTH_SERVICE_HOST)"
+            {{- end }}
           - name: OAUTH_SERVICE_PORT
-            value: "$(AUTH_SERVICE_PORT)"
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: $(AUTH_SERVICE_PORT)
+            {{- end }}
           - name: PORT
             value: "{{ .Values.container.port }}"
           - name: SEND_EMAIL_TO_GOV_NOTIFY

--- a/_infra/helm/party/values.yaml
+++ b/_infra/helm/party/values.yaml
@@ -42,3 +42,7 @@ email:
     key: aardvark
   token:
     salt: aardvark
+
+dns:
+  enabled: false
+  wellKnownPort: 8080


### PR DESCRIPTION
# Motivation and Context
Adds kube_dns addresses for all connecting services to allow us to have circular references