### PR TITLE
New structlog processor for Google Cloud Logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 
 lint:
 	pipenv run flake8 ./ras_party ./test
-	pipenv check ./ras_party ./test
+	# pipenv check ./ras_party ./test
 
 test: lint
 	APP_SETTINGS=TestingConfig pipenv run pytest test --cov ras_party --cov-report term-missing

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ build:
 
 lint:
 	pipenv run flake8 ./ras_party ./test
-	export PIPENV_PYUP_API_KEY=""
-	pipenv check ./ras_party ./test
+	# pipenv check ./ras_party ./test
 
 test: lint
 	APP_SETTINGS=TestingConfig pipenv run pytest test --cov ras_party --cov-report term-missing

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ build:
 
 lint:
 	pipenv run flake8 ./ras_party ./test
-	# pipenv check ./ras_party ./test
+	export PIPENV_PYUP_API_KEY=""
+	pipenv check ./ras_party ./test
 
 test: lint
 	APP_SETTINGS=TestingConfig pipenv run pytest test --cov ras_party --cov-report term-missing

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.0
+appVersion: 2.0.1

--- a/logger_config.py
+++ b/logger_config.py
@@ -29,6 +29,22 @@ def logger_initial_config(log_level=None):
         event_dict['service'] = service_name
         return event_dict
 
+    def add_severity_level(logger, method_name, event_dict): # pylint: disable=unused-argument
+        """
+        Add the log level to the event dict.
+        """
+        if method_name == "warn":
+            # The stdlib has an alias
+            method_name = "warning"
+
+        event_dict["severity"] = method_name
+        return event_dict
+
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
-    configure(processors=[add_log_level, filter_by_level, add_service, format_exc_info,
-                          TimeStamper(fmt=logger_date_format, utc=True, key="created_at"), JSONRenderer(indent=indent)])
+    configure(processors=[add_severity_level,
+                          add_log_level,
+                          filter_by_level,
+                          add_service,
+                          format_exc_info,
+                          TimeStamper(fmt=logger_date_format, utc=True, key="created_at"),
+                          JSONRenderer(indent=indent)])


### PR DESCRIPTION
# Motivation and Context
Added "severity level" processor to structlog, so Google Cloud Logging can parse the severity
<!--- Why is this change required? What problem does it solve? -->

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
make test, or
pipenv run python3 run_tests.py
Spin up cluster in Dev, with ras-party pod built from image tag "cloud-logging-new"; generate an error; check Stackdriver logs for correct parsing and severity levels.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/wDSxYgCQ
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
