### PR TITLE
Remove old method of sending emails

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.13
+appVersion: 2.0.14

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.14
+appVersion: 2.0.15

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -206,8 +206,6 @@ spec:
                 key: email-token-salt
           - name: PORT
             value: "{{ .Values.container.port }}"
-          - name: USE_PUBSUB_FOR_EMAIL
-            value: "{{ .Values.email.pubsub.enabled }}"
           - name: SEND_EMAIL_TO_GOV_NOTIFY
             value: "{{ .Values.email.enabled }}"
           resources:

--- a/_infra/helm/party/values.yaml
+++ b/_infra/helm/party/values.yaml
@@ -48,7 +48,6 @@ email:
   token:
     salt: aardvark
   pubsub:
-    enabled: false
     topic: ras-rm-notify-test
 
 dns:

--- a/config.py
+++ b/config.py
@@ -36,7 +36,6 @@ class Config(object):
     IAC_URL = os.getenv('IAC_URL')
     SURVEY_URL = os.getenv('SURVEY_URL')
 
-    USE_PUBSUB_FOR_EMAIL = os.getenv('USE_PUBSUB_FOR_EMAIL', False)
     GOOGLE_CLOUD_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT', 'test-project-id')
     NOTIFY_PUBSUB_TOPIC = os.getenv('NOTIFY_PUBSUB_TOPIC', 'ras-rm-notify-test')
 
@@ -51,13 +50,11 @@ class Config(object):
 
 
 class DevelopmentConfig(Config):
-
     DEBUG = True
     LOGGING_LEVEL = 'DEBUG'
 
 
 class TestingConfig(DevelopmentConfig):
-
     DEBUG = True
     LOGGING_LEVEL = 'ERROR'
     SECRET_KEY = 'aardvark'

--- a/test/test_notify_gateway.py
+++ b/test/test_notify_gateway.py
@@ -6,70 +6,7 @@ from flask_testing import TestCase
 
 from ras_party.controllers.notify_gateway import NotifyGateway
 from ras_party.exceptions import RasNotifyError
-from ras_party.support.requests_wrapper import Requests
 from run import create_app
-from test.mocks import MockRequests
-from test.party_client import PartyTestClient
-
-
-class TestNotifyGateway(PartyTestClient):
-    """ Notify gateway test class"""
-    def setUp(self):
-        self.mock_requests = MockRequests()
-        Requests._lib = self.mock_requests
-
-    def test_notify_sends_notification_with_basic_message(self):
-        # Given a mocked notify gateway and response
-        self.mock_requests.post.response_payload = '{"id": "notification id"}'
-
-        notify = NotifyGateway(current_app.config)
-        # When an email is sent
-        notify.request_to_notify('email', 'email_verification')
-        # Then send_email_notification is called
-
-        expected_data = {"emailAddress": "email"}
-
-        expected_request = {"auth": (current_app.config['SECURITY_USER_NAME'],
-                                     current_app.config['SECURITY_USER_PASSWORD']),
-                            "timeout": 20, "json": expected_data}
-
-        self.mock_requests.post.assert_called_with(
-            "http://mockhost:5555/emails/email_verification_id",
-            expected_request)
-
-    def test_notify_sends_notification_with_extended_message(self):
-        # Given a mocked notify gateway and response
-        self.mock_requests.post.response_payload = '{"id": "notification id"}'
-
-        notify = NotifyGateway(current_app.config)
-        # When an email is sent
-        personalisation = {
-            "name": "A person"
-        }
-        notify.request_to_notify("email", 'request_password_change', personalisation=personalisation,
-                                 reference="reference")
-        # Then send_email_notification is called
-        expected_data = {"emailAddress": "email", "personalisation": personalisation, "reference": "reference"}
-        expected_request = {"auth": (current_app.config['SECURITY_USER_NAME'],
-                                     current_app.config['SECURITY_USER_PASSWORD']),
-                            "timeout": 20, "json": expected_data}
-
-        self.mock_requests.post.assert_called_with(
-            "http://mockhost:5555/emails/request_password_change_id",
-            expected_request)
-
-    def test_notify_exception_is_translated_to_ras_exception(self):
-        # Given a mocked gov.uk notify and exception
-        def mock_post_notify(*args, **kwargs):
-            raise Exception("Generic Error")
-
-        self.mock_requests.post = mock_post_notify
-
-        # When an email is sent
-        notify = NotifyGateway(current_app.config)
-        # Then a RasNotifyError is raised
-        with self.assertRaises(RasNotifyError):
-            notify.request_to_notify('email', 'request_password_change')
 
 
 class TestNotifyGatewayUnit(TestCase):

--- a/test/test_notify_gateway.py
+++ b/test/test_notify_gateway.py
@@ -99,7 +99,6 @@ class TestNotifyGatewayUnit(TestCase):
         publisher = MagicMock()
         publisher.topic_path.return_value = 'projects/test-project-id/topics/ras-rm-notify-test'
         # Given a mocked notify gateway
-        current_app.config['USE_PUBSUB_FOR_EMAIL'] = True
         notify = NotifyGateway(current_app.config)
         notify.publisher = publisher
         result = notify.request_to_notify('test@email.com', 'notify_account_locked')
@@ -115,7 +114,6 @@ class TestNotifyGatewayUnit(TestCase):
         publisher = MagicMock()
         publisher.topic_path.return_value = 'projects/test-project-id/topics/ras-rm-notify-test'
         # Given a mocked notify gateway
-        current_app.config['USE_PUBSUB_FOR_EMAIL'] = True
         notify = NotifyGateway(current_app.config)
         notify.publisher = publisher
         personalisation = {"first_name": "testy", "last_name": "surname"}
@@ -134,7 +132,6 @@ class TestNotifyGatewayUnit(TestCase):
         publisher.publish.return_value = future
 
         # Given a mocked notify gateway
-        current_app.config['USE_PUBSUB_FOR_EMAIL'] = True
         notify = NotifyGateway(current_app.config)
         notify.publisher = publisher
         with self.assertRaises(RasNotifyError):


### PR DESCRIPTION
# Motivation and Context
Now that we've verified that emails are being sent via pubsub, we can remove the old code that contacted the old notify-gateway-service.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
