### PR TITLE
add proxy resource requests

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.24
+appVersion: 2.0.25

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
               secretKeyRef:
                 name: db-config
                 key: db-port
+          resources:
+            {{- toYaml .Values.resources.proxy | nindent 12 }}
         {{- end }}
         - name: {{ .Chart.Name }}
           {{- if eq .Values.image.tag "latest"}}
@@ -209,4 +211,4 @@ spec:
           - name: SEND_EMAIL_TO_GOV_NOTIFY
             value: "{{ .Values.email.enabled }}"
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.application | nindent 12 }}

--- a/_infra/helm/party/values.yaml
+++ b/_infra/helm/party/values.yaml
@@ -25,12 +25,20 @@ service:
   port: 8080
 
 resources:
-  requests:
-    memory: "500Mi"
-    cpu: "25m"
-  limits:
-    cpu: "100m"
-    memory: "1500Mi"
+  application:
+    requests:
+      memory: "500Mi"
+      cpu: "25m"
+    limits:
+      memory: "1500Mi"
+      cpu: "200m"
+  proxy:
+    requests:
+      memory: "25Mi"
+      cpu: "5m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 autoscaling: false
 scaleAt:

--- a/_infra/helm/party/values.yaml
+++ b/_infra/helm/party/values.yaml
@@ -28,10 +28,10 @@ resources:
   application:
     requests:
       memory: "500Mi"
-      cpu: "25m"
+      cpu: "35m"
     limits:
       memory: "1500Mi"
-      cpu: "200m"
+      cpu: "400m"
   proxy:
     requests:
       memory: "25Mi"


### PR DESCRIPTION
Add proxy resource requests. Given the proxy a cpu request of `5m`. This is due to the relatively low request for the application. We dont the proxy quota preventing our resource monitoring from triggering an autoscale
I have upped the request and limit of the application as a sample spike quickly shot to 100% limit.