### PR TITLE
Fix bug that broke endpoint if any ce was blank

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.32
+appVersion: 2.0.33

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -63,6 +63,9 @@ def get_business_attributes(business_id, session, collection_exercise_ids=None):
     """
     Get a list of businesses by business id and (optionally) collection exercise ids
 
+    The result is keyed on collection_exercise, so if the collection_exercise is missing, it won't be included
+    in the records.
+
     :param business_id: A business's uuid
     :param collection_exercise_ids: A list of collection exercise ids
     :param session: A database session
@@ -89,7 +92,8 @@ def get_business_attributes(business_id, session, collection_exercise_ids=None):
 
     logger.debug("Database result", attributes=attributes)
 
-    return {attribute.collection_exercise: attribute.to_dict() for attribute in attributes}
+    return {attribute.collection_exercise: attribute.to_dict()
+            for attribute in attributes if attribute.collection_exercise}
 
 
 @with_query_only_db_session

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -90,8 +90,6 @@ def get_business_attributes(business_id, session, collection_exercise_ids=None):
     else:
         attributes = query_business_attributes(business_id, session)
 
-    logger.debug("Database result", attributes=attributes)
-
     return {attribute.collection_exercise: attribute.to_dict()
             for attribute in attributes if attribute.collection_exercise}
 

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -76,7 +76,7 @@ def get_business_attributes(business_id, session, collection_exercise_ids=None):
     try:
         uuid.UUID(business_id)
     except ValueError:
-        logger.warn("Invalid party uuid value", business_id=business_id)
+        logger.warning("Invalid party uuid value", business_id=business_id)
         raise BadRequest(f"'{business_id}' is not a valid UUID format for property 'id'")
 
     if collection_exercise_ids:
@@ -84,7 +84,7 @@ def get_business_attributes(business_id, session, collection_exercise_ids=None):
             try:
                 uuid.UUID(collection_exercise_id)
             except ValueError:
-                logger.warn("Invalid collection exercise uuid value", collection_exercise_id=collection_exercise_id)
+                logger.warning("Invalid collection exercise uuid value", collection_exercise_id=collection_exercise_id)
                 raise BadRequest(f"'{collection_exercise_id}' is not a valid UUID format for property 'id'")
         attributes = query_business_attributes_by_collection_exercise(business_id, collection_exercise_ids, session)
     else:

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -201,13 +201,16 @@ class BusinessAttributes(Base):
 
         :return: A dict with all the columns and their values
         """
+        created_on = None
+        if self.created_on:
+            created_on = self.created_on.strftime("%Y-%m-%d, %H:%M:%S")
         return {
             'id': self.id,
-            'business_id': self.business_id,
+            'business_id': str(self.business_id),
             'sample_summary_id': self.sample_summary_id,
             'collection_exercise': self.collection_exercise,
             'attributes': self.attributes,
-            'created_on': self.created_on,
+            'created_on': created_on,
             'name': self.name,
             'trading_as': self.trading_as
         }

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -203,7 +203,7 @@ class BusinessAttributes(Base):
         """
         created_on = None
         if self.created_on:
-            created_on = self.created_on.strftime("%Y-%m-%d, %H:%M:%S")
+            created_on = self.created_on.strftime("%Y-%m-%d %H:%M:%S")
         return {
             'id': self.id,
             'business_id': str(self.business_id),

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -201,16 +201,13 @@ class BusinessAttributes(Base):
 
         :return: A dict with all the columns and their values
         """
-        created_on = None
-        if self.created_on:
-            created_on = self.created_on.strftime("%Y-%m-%d %H:%M:%S")
         return {
             'id': self.id,
             'business_id': str(self.business_id),
             'sample_summary_id': self.sample_summary_id,
             'collection_exercise': self.collection_exercise,
             'attributes': self.attributes,
-            'created_on': created_on,
+            'created_on': self.created_on.strftime("%Y-%m-%d %H:%M:%S"),
             'name': self.name,
             'trading_as': self.trading_as
         }

--- a/test/controllers/test_business_controller.py
+++ b/test/controllers/test_business_controller.py
@@ -1,3 +1,5 @@
+import datetime
+import uuid
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -21,11 +23,11 @@ class TestBusinessController(TestCase):
     def get_business_attribute_object(self, collection_exercise_id=valid_collection_exercise_id):
         base = BusinessAttributes()
         base.id = "id"
-        base.business_id = self.valid_business_id
+        base.business_id = uuid.UUID(self.valid_business_id)
         base.sample_summary_id = "sample_summary_id"
         base.collection_exercise = collection_exercise_id
         base.attributes = {}
-        base.created_on = "created_on"
+        base.created_on = datetime.datetime.strptime("2021-01-30 00:00:00", "%Y-%m-%d %H:%M:%S")
         base.name = "name"
         base.trading_as = "trading_as"
         return base
@@ -58,7 +60,7 @@ class TestBusinessController(TestCase):
                 'attributes': {},
                 'business_id': self.valid_business_id,
                 'collection_exercise': self.valid_collection_exercise_id,
-                'created_on': "created_on",
+                'created_on': "2021-01-30 00:00:00",
                 'id': "id",
                 'name': "name",
                 'sample_summary_id': "sample_summary_id",
@@ -76,7 +78,7 @@ class TestBusinessController(TestCase):
                 'attributes': {},
                 'business_id': self.valid_business_id,
                 'collection_exercise': self.valid_collection_exercise_id,
-                'created_on': "created_on",
+                'created_on': "2021-01-30 00:00:00",
                 'id': "id",
                 'name': "name",
                 'sample_summary_id': "sample_summary_id",
@@ -86,7 +88,7 @@ class TestBusinessController(TestCase):
                 'attributes': {},
                 'business_id': self.valid_business_id,
                 'collection_exercise': self.another_valid_collection_exercise_id,
-                'created_on': "created_on",
+                'created_on': "2021-01-30 00:00:00",
                 'id': "id",
                 'name': "name",
                 'sample_summary_id': "sample_summary_id",
@@ -102,6 +104,26 @@ class TestBusinessController(TestCase):
         value = business_controller.\
             get_business_attributes.__wrapped__(self.valid_business_id, session,
                                                 collection_exercise_ids=self.valid_collection_exercises)
+        self.assertEqual(expected_output, value)
+
+    def test_query_business_attributes_one_missing_collection_exercise_id(self):
+        """Any attributes with a mission collection exercise id won't be inlcuded in the result"""
+        expected_output = {
+            self.valid_collection_exercise_id: {
+                'attributes': {},
+                'business_id': self.valid_business_id,
+                'collection_exercise': self.valid_collection_exercise_id,
+                'created_on': "2021-01-30 00:00:00",
+                'id': "id",
+                'name': "name",
+                'sample_summary_id': "sample_summary_id",
+                'trading_as': "trading_as"
+            }
+        }
+        session = MagicMock()
+        session.query().filter().all.return_value = [self.get_business_attribute_object(),
+                                                     self.get_business_attribute_object(collection_exercise_id=None)]
+        value = business_controller.get_business_attributes.__wrapped__(self.valid_business_id, session)
         self.assertEqual(expected_output, value)
 
 


### PR DESCRIPTION
# Motivation and Context
There is a bug in the attributes endpoint where businesses with empty collection exercises in their attributes.  This PR makes it so attributes without a collection exercise id aren't included in the output.  The majority of them should have one so not including them shouldn't happen too frequently.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
