### PR TITLE
Fix bug where 'verbose' removes data that is already there

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.44
+appVersion: 2.0.45

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -119,7 +119,7 @@ class Business(Base):
         :return: A dict containing both the summary data and business attributes for the business
         :rtype: dict
         """
-        d = self.to_business_summary_dict()
+        d = self.to_business_summary_dict(collection_exercise_id)
         attributes = self._get_attributes_for_collection_exercise(collection_exercise_id)
         return dict(d, **attributes.attributes)
 


### PR DESCRIPTION
# Motivation and Context
Currently, when you add `?verbose=true` to the end of `business/ref/<ref>` it actually removes a bunch of key details like the id, name, etc.  This PR fixes that and makes it so that verbose only adds more and takes nothing away!

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
