### PR TITLE
Reducing number of gunicron workers to 6

### DIFF
--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -9,5 +9,5 @@ WORKDIR /app
 COPY . /app
 RUN pipenv install --deploy --system
 
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "--workers", "8", "--worker-class", "gevent", "--worker-connections" ,"1000", "--timeout", "0", "--keep-alive", "2", "app:app"]
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "--workers", "6", "--worker-class", "gevent", "--worker-connections" ,"1000", "--timeout", "0", "--keep-alive", "2", "app:app"]
 

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.10
+version: 2.4.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.10
+appVersion: 2.4.11
 


### PR DESCRIPTION
# What and why?
Reducing the number of gunicorn workers to 6 to see if it will increase the amount of memory each worker has and stop the crashes when it's requesting too many parties for the dummy ru_refs in preprod and prod
# How to test?
- Go to https://rops-preprod.onsdigital.uk/reporting-units/{ru_ref}/surveys/{survey_id} and refresh until a 500 error happens
- Deploy to preprod as it takes too long to create enough parties to test this properly in dev
- Go to https://rops-preprod.onsdigital.uk/reporting-units/{ru_ref}/surveys/{survey_id} and refresh until you are confident that the error is not happening
- You can also test sample file load times, but this will take about 10 minutes in preprod with a 40k sample
# Trello
https://trello.com/c/dKQ7HzZ5/1790-bug-error-500-on-rops-ru-page-when-loading-survey-data