### PR TITLE
Improve logging and statuses around new accounts

### DIFF
--- a/API.md
+++ b/API.md
@@ -646,6 +646,7 @@ Returns:
   * Posts a respondent to the database and generates their `sampleUnitRef`, `partyID` and `enrolments`.
   * If passed an `id` parameter it will use this instead of generating a new UUID.
   * Sets `businessRespondentStatus` to 'CREATED'.
+  * Returns a 200 on success, a 400 if data is missing or iac is invalid and 409 if the user email already exists.
 
 #### Example JSON Payload
 
@@ -658,7 +659,6 @@ Returns:
     "password" : "password",
     "telephone" : "01234567890",
     "enrolmentCode" : "<enrolmentCode>",
-    "sampleUnitType" : "BI"
   }
 ]
 

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.12
+version: 2.4.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.12
+appVersion: 2.4.13
 

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -102,8 +102,8 @@ def post_respondent(party, session):
 
     existing = query_respondent_by_email(party["emailAddress"].lower(), session)
     if existing:
-        logger.info("Email already exists", party_uuid=str(existing.party_uuid))
-        raise BadRequest("Email address already exists")
+        logger.info("Email already exists", party_uuid=str(existing.party_uuid), email=obfuscate_email(party["emailAddress"].lower()))
+        raise Conflict("Email address already exists")
 
     case_context = request_case(party["enrolmentCode"])
     case_id = case_context["id"]

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -102,7 +102,11 @@ def post_respondent(party, session):
 
     existing = query_respondent_by_email(party["emailAddress"].lower(), session)
     if existing:
-        logger.info("Email already exists", party_uuid=str(existing.party_uuid), email=obfuscate_email(party["emailAddress"].lower()))
+        logger.info(
+            "Email already exists",
+            party_uuid=str(existing.party_uuid),
+            email=obfuscate_email(party["emailAddress"].lower()),
+        )
         raise Conflict("Email address already exists")
 
     case_context = request_case(party["enrolmentCode"])

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -61,7 +61,7 @@ def post_respondent_reset_password_by_email():
 def post_respondent():
     payload = request.get_json() or {}
     response = account_controller.post_respondent(payload)
-    return make_response(jsonify(response), 200)
+    return jsonify(response)
 
 
 @account_view.route("/emailverification/<token>", methods=["PUT"])

--- a/test/controllers/test_account_controller.py
+++ b/test/controllers/test_account_controller.py
@@ -18,7 +18,6 @@ from ras_party.support.verification import generate_email_token
 from run import create_app
 
 
-# noinspection DuplicatedCode
 class TestAccountController(TestCase):
     """
     Tests the functions in the account_controller.  Note, the __wrapped__ attribute allows us to get at the function


### PR DESCRIPTION
# What and why?

The errors around account creation failures weren't easy to diagnose, so this PR adds a little more logging and more accurate status codes to help figure out future issues.

# How to test?

- Deploy this and the frontstage PR with the same branch name (https://github.com/ONSdigital/ras-frontstage/pull/848) to your environment.
- Run the acceptance tests to seed data
- Try to create an account that already exists (example@example.com) and look at both the frontstage and party logs.  The logging should make it more clear what is going on.
- Try and create an account to make sure nothing else has broken!


# Trello
