### PR TITLE
Upgrade flask and werkzeug to latest version in ras-party

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 42194 -i 51668 -i 51499 -i 51457
+	pipenv check -i 51668
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8 --exclude=./scripts
 
 lint-check:
-	pipenv check -i 42194 -i 51668 -i 51499 -i 51457
+	pipenv check -i 51668
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8 --exclude=./scripts

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 51668
+	pipenv check -i 51668 -i 42194
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8 --exclude=./scripts
 
 lint-check:
-	pipenv check -i 51668
+	pipenv check -i 51668 -i 42194
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8 --exclude=./scripts

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 42194 -i 51668
+	pipenv check -i 42194 -i 51668 -i 51499 -i 51457
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8 --exclude=./scripts
 
 lint-check:
-	pipenv check -i 42194 -i 51668
+	pipenv check -i 42194 -i 51668 -i 51499 -i 51457
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8 --exclude=./scripts

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ python_version = "3.10"
 
 [packages]
 alembic = "*"
-flask = "==2.1.3"
+flask = "==2.2.2"
 flask-cors = "*"
 flask-httpauth = "*"
 gunicorn = "*"
@@ -24,7 +24,7 @@ sqlalchemy-utils = "*"
 structlog = "*"
 requestsdefaulter = "*"
 psycopg2-binary = "*"
-werkzeug = "==2.0.3"
+werkzeug = "==2.2.2"
 
 [dev-packages]
 black = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ python_version = "3.10"
 
 [packages]
 alembic = "*"
-flask = "==2.2.2"
+flask = "*"
 flask-cors = "*"
 flask-httpauth = "*"
 gunicorn = "*"
@@ -24,7 +24,7 @@ sqlalchemy-utils = "*"
 structlog = "*"
 requestsdefaulter = "*"
 psycopg2-binary = "*"
-werkzeug = "==2.2.2"
+werkzeug = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "474993bb59468aa2d1621bdba26b3fb6139bd6416487fd31304741af88f1f736"
+            "sha256": "a88e006e8ec204dd1e8dc17945f92c24a261755dd7234f21f39b11fe0eab2d98"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -66,11 +66,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:15972e5017df0575c3d6c090ba168b6db90259e620ac8d7ea813a396bad5b6cb",
-                "sha256:9013281a7402ad527f8fd56375164f3aa021ecfaff89bfe3825346c24f87e04c"
+                "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b",
+                "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"
             ],
             "index": "pypi",
-            "version": "==2.1.3"
+            "version": "==2.2.2"
         },
         "flask-cors": {
             "hashes": [
@@ -420,23 +420,23 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:25266bf373ee06d5d66f9eb1ec9d434b243dccce5c32faf151054cfa6f9dcbf1",
-                "sha256:260e346927fd4e6fbb49ab545137b19610c24a1d853dc5f29ddf777ab1987211",
-                "sha256:2c6a4d13732d9b094db31b3841986c38b17ac61a3fe05ee26a779d94c4c3fb43",
-                "sha256:4922e3320ed70e81f05060822da36923d09fd9e04e17f411f2d8d8d0070f9f5c",
-                "sha256:4b75c947289a2e9c1f37d21c593f1ef6fb4fed33977dfb2ac84f799eb29a8ff4",
-                "sha256:4d01ef83517c181d60ea1c6d0b2f644be250ade740d6554a2f5a021b1ad622e3",
-                "sha256:553e35c0878f6855e55f01a14561e6bce6df79b6636a5acf83b9d9ac7eab7922",
-                "sha256:85ccb4753ee21de7dc81a7a68a051f25dbe133ffa01a639ac998427d0b223387",
-                "sha256:a5a14b907a191319e7a58b38c583bbf50deb21e002f723a912c5e4f6969a778e",
-                "sha256:a944dc9550baae276afc7dc8193191d4c2ad660270a1e5ed5a71539817ebe2e2",
-                "sha256:bab4b21a986ded225b9392c07ce21c35d790951f51e1ebfd32e4d443b05c3726",
-                "sha256:c3b9e329b4c247dc3ba5c50f60915a84e08278eb6d9e3fa674d0d04ff816bfd7",
-                "sha256:d91a47c77b33580024b0271b65bb820c4e0264c25eb49151ad01e691de8fa0b6",
-                "sha256:efb16b16fd3eef25357f84d516062753014b76279ce4e0ec4880badd2fba7370"
+                "sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30",
+                "sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b",
+                "sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc",
+                "sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791",
+                "sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717",
+                "sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec",
+                "sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7",
+                "sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab",
+                "sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2",
+                "sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5",
+                "sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1",
+                "sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462",
+                "sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97",
+                "sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.21.11"
+            "version": "==4.21.12"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -707,18 +707,18 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8",
-                "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"
+                "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f",
+                "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"
             ],
             "index": "pypi",
-            "version": "==2.0.3"
+            "version": "==2.2.2"
         },
         "zope.event": {
             "hashes": [
-                "sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42",
-                "sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330"
+                "sha256:73d9e3ef750cca14816a9c322c7250b0d7c9dbc337df5d1b807ff8d3d0b9e97c",
+                "sha256:81d98813046fc86cc4136e3698fee628a3282f9c320db18658c21749235fce80"
             ],
-            "version": "==4.5.0"
+            "version": "==4.6"
         },
         "zope.interface": {
             "hashes": [
@@ -888,11 +888,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:15972e5017df0575c3d6c090ba168b6db90259e620ac8d7ea813a396bad5b6cb",
-                "sha256:9013281a7402ad527f8fd56375164f3aa021ecfaff89bfe3825346c24f87e04c"
+                "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b",
+                "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"
             ],
             "index": "pypi",
-            "version": "==2.1.3"
+            "version": "==2.2.2"
         },
         "flask-testing": {
             "hashes": [
@@ -918,11 +918,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
+                "sha256:dd8bbc5c0990f2a095d754e50360915f73b4c26fc82733eb5bfc6b48396af4d2",
+                "sha256:e486966fba83f25b8045f8dd7455b0a0d1e4de481e1d7ce4669902d9fb85e622"
             ],
             "index": "pypi",
-            "version": "==5.10.1"
+            "version": "==5.11.2"
         },
         "itsdangerous": {
             "hashes": [
@@ -1114,11 +1114,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8",
-                "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"
+                "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f",
+                "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"
             ],
             "index": "pypi",
-            "version": "==2.0.3"
+            "version": "==2.2.2"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a88e006e8ec204dd1e8dc17945f92c24a261755dd7234f21f39b11fe0eab2d98"
+            "sha256": "5fb516074979c07b48d64c9f1493fd08dbd73dad9e83a66dd40b87ff3f0a3821"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:0a024d7f2de88d738d7395ff866997314c837be6104e90c5724350313dee4da4",
-                "sha256:cd0b5e45b14b706426b833f06369b9a6d5ee03f826ec3238723ce8caaf6e5ffa"
+                "sha256:6af6792fe699730b27480382701b16028ebbaac6bc5cd4f06daf5fa3e4690364",
+                "sha256:e8ce855f731d92cfdbf9a71d148401fcc420399927817c6e2c0b6a5f31db745d"
             ],
             "index": "pypi",
-            "version": "==1.8.1"
+            "version": "==1.9.0"
         },
         "attrs": {
             "hashes": [

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.20
+version: 2.4.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.20
+appVersion: 2.4.21
 

--- a/run.py
+++ b/run.py
@@ -3,7 +3,7 @@ import os
 from json import loads
 
 import structlog
-from flask import Flask, _app_ctx_stack
+from flask import Flask
 from flask_cors import CORS
 from retrying import RetryError, retry
 from sqlalchemy import column, create_engine, text
@@ -50,12 +50,9 @@ def create_app(config=None):
 def create_database(db_connection, db_schema):
     from ras_party.models import models
 
-    def current_request():
-        return _app_ctx_stack.__ident_func__()
-
     engine = create_engine(db_connection)
-    session = scoped_session(sessionmaker(), scopefunc=current_request)
-    session.configure(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    connection = engine.connect()
+    session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=connection))
     engine.session = session
     models.Base.query = session.query_property()
 

--- a/run.py
+++ b/run.py
@@ -50,9 +50,9 @@ def create_app(config=None):
 def create_database(db_connection, db_schema):
     from ras_party.models import models
 
-    engine = create_engine(db_connection)
-    connection = engine.connect()
-    session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=connection))
+    engine = create_engine(db_connection, echo=True)
+    session = scoped_session(sessionmaker())
+    session.configure(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
     engine.session = session
     models.Base.query = session.query_property()
 


### PR DESCRIPTION
# What and why?
There is a requirement to upgrade Flask and Werkzeug versions to their respective latest versions. This caused an issue due to a deprecated method call. This call has been replaced.
 
# How to test?
Check the services that use the party service to check that everything is running correctly.

# Trello
https://trello.com/c/4SRmRPD0/2127-upgrade-flask-and-werkzeug-to-latest-version-in-ras-party