### PR TITLE
Remove echo to have less db logging and noise

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.22
+version: 2.4.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.22
+appVersion: 2.4.23
 

--- a/run.py
+++ b/run.py
@@ -50,7 +50,7 @@ def create_app(config=None):
 def create_database(db_connection, db_schema):
     from ras_party.models import models
 
-    engine = create_engine(db_connection, echo=True)
+    engine = create_engine(db_connection)
     session = scoped_session(sessionmaker())
     session.configure(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
     engine.session = session


### PR DESCRIPTION
# What and why?

The logs in party were crazy long because it was spitting out all the stuff that the SQL engine was doing.  Removing the echo means the logging isn't so crazy and noisy.

# How to test?

- Deploy PR to environment
- Do anything that uses the party service (look at a respondent or a secure message? or just log in frontstage as a user)
- Notice there is no SQL engine logs, just the specific logging we put in.

# Trello
