### PR TITLE
RAS-717 Update auto scalling to v2

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.24
+version: 2.4.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.24
+appVersion: 2.4.25
 

--- a/_infra/helm/party/templates/hpa.yaml
+++ b/_infra/helm/party/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Chart.Name }}


### PR DESCRIPTION
# What and why?
Update autoscaling from v2beta2 to v2
# How to test?
Deploy via helm. I initial built a whole release then deleted the services associated in the charts. You will need to update your [values.yaml](https://github.com/ONSdigital/ras-party/blob/main/_infra/helm/party/values.yaml) file making sure env, namespace, project, topic and autoscaling is true

```
kubectl delete deployment party --namespace <your namespace>
kubectl delete service party --namespace <your namespace>
kubectl delete cronjob party-scheduler-delete-respondents --namespace <your namespace>
kubectl delete cronjob party-scheduler-remove-expired-pending-surveys --namespace <your namespace>
kubectl delete externalsecret party --namespace <your namespace>
```

This should then let you deploy with 

```
helm install party ./_infra/helm/party
```

Give it a couple of minutes as HPA takes a while, then click on party on gcp and you should see HPA autoscale with a green tick 

![image](https://user-images.githubusercontent.com/14179817/233018466-b34a118c-dae6-4758-a86a-89d452987ea8.png)

# Trello
