### PR TITLE
RAS-850 Cloud sql proxy term timeout and verbose

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.29
+version: 2.4.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.29
+appVersion: 2.4.30
 

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -41,7 +41,9 @@ spec:
           command: ["/cloud_sql_proxy",
                     "-instances=$(SQL_INSTANCE_NAME)=tcp:$(DB_PORT)",
                     "-ip_address_types=PRIVATE",
-                    "-credential_file=/secrets/cloudsql/credentials.json"]
+                    "-credential_file=/secrets/cloudsql/credentials.json",
+                    "-term_timeout=30s",
+                    "-verbose=false"]
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false


### PR DESCRIPTION
# What and why?
This PR adds a wait time for cloud_sql_proxy and stops verbose logging. Currently we deploy the app with a side car cloud_sql_proxy container to access the db. However when a pod is redeployed and the proxy container is sent a SIGTERM the container does not close down gracefully and will kill all connections instantly (i.e sql queries). This naturally gets passed back up the chain to the respondent who will get an error. With us currently using a default pool of 5 and overflow of 10, it means anything up to 15 respondents could get an error when we deploy a new release to prod, which ain't good. 
It almost certainly is the reason we see hanging queries and spikes on rollouts in Grafana. This PR adds a term_timeout which will allow the proxy to complete it's query (at least give it 30 seconds to do so) before it creates a revision. 

The PR also stops verbose logging which is set by default and why we get so many records in the logs we just don't need. The logging will still show start-up and errors which is fine for what we need

# How to test?
This is a bit painful. First you need a sqlProxyEnabled environment, which means you need to use performance, so run the relevant concourse pipeline and then spinnaker, (let the tests run, you need the traffic when redeploying). 

Now because this is a chart change and how we use spinnaker is a bit rubbish you must deploy from your local, which would usually be ```helm upgrade --install party ./_infra/helm/party```. However this will give you a spinnaker managed-by issue as it's going to be currently spinnaker and you need it to be HELM, so clear the components down (you only need to do this once).

```
ras context performance performance
kubectl delete deployment party --namespace performance
kubectl delete service party --namespace performance
kubectl delete cronjob party-scheduler-delete-respondents --namespace performance
kubectl delete cronjob party-scheduler-remove-expired-pending-surveys --namespace performance
kubectl delete externalsecret party --namespace performance
```
You also need to adjust the values.yaml file to be correct, updating env, namespace (both to performance) and the database bit which details can be [found here](https://github.com/ONSdigital/ras-rm-config/blob/main/performance/party/values.yaml#L4) You also need to adjust the project to be correct

Now redeploy but don't use this branch initially, we want to see the connection issue firsts.
```helm upgrade --install party ./_infra/helm/party```

In fact deploy a few times and look in the logs and see ```Error during SIGTERM shutdown: 8 active connections still exist after waiting for 0s. ```
Now checkout out this branch and redeploy, 1st time you will still see the error above as naturally that is its current setting before replacing with this, but notice on future re-deployments you don't get any errors. Also notice all the extra logging has gone (N.B this is one of 14 services which uses a side car proxy, so there will still be those logs unless you want to do it for all service, it's the party proxy I am talking about)


# Trello
