### PR TITLE
Change to database exception handling

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1261,11 +1261,12 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
-                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+                "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
+                "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.2"
+            "version": "==3.1.3"
         },
         "markupsafe": {
             "hashes": [

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.35
+version: 2.4.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.4.35
+appVersion: 2.4.36

--- a/ras_party/support/session_decorator.py
+++ b/ras_party/support/session_decorator.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 import structlog
 from flask import current_app
-from sqlalchemy.exc import SQLAlchemyError, OperationalError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
 logger = structlog.wrap_logger(logging.getLogger(__name__))
 


### PR DESCRIPTION
# What and why?
DB exception handling was a little bit of a scattershot approach when implemented because SQLAlchemy's exceptions aren't that good. This is a best attempt at refining it a bit for alerting purposes

# How to test?
- Spin up an environment
- Kill postgres
- Do anything that would call Party
- Check Party logs for the exception

# Jira
RAS-901