### PR TITLE
quieten logging statements on cronjobs

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.2
+version: 2.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.2
+appVersion: 2.5.3

--- a/_infra/helm/party/templates/cronjob_delete_respondents.yaml
+++ b/_infra/helm/party/templates/cronjob_delete_respondents.yaml
@@ -28,5 +28,5 @@ spec:
             args:
             - /bin/sh
             - -c
-            - curl -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET)
+            - curl -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET) 2> /dev/null
           restartPolicy: OnFailure

--- a/_infra/helm/party/templates/cronjob_delete_respondents.yaml
+++ b/_infra/helm/party/templates/cronjob_delete_respondents.yaml
@@ -28,5 +28,5 @@ spec:
             args:
             - /bin/sh
             - -c
-            - curl -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET) 2> /dev/null
+            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET)
           restartPolicy: OnFailure

--- a/_infra/helm/party/templates/cronjob_remove_pending_surveys.yaml
+++ b/_infra/helm/party/templates/cronjob_remove_pending_surveys.yaml
@@ -27,5 +27,5 @@ spec:
             args:
             - /bin/sh
             - -c
-            - curl -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET) 2> /dev/null
+            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET)
           restartPolicy: OnFailure

--- a/_infra/helm/party/templates/cronjob_remove_pending_surveys.yaml
+++ b/_infra/helm/party/templates/cronjob_remove_pending_surveys.yaml
@@ -27,5 +27,5 @@ spec:
             args:
             - /bin/sh
             - -c
-            - curl -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET)
+            - curl -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)/$(TARGET) 2> /dev/null
           restartPolicy: OnFailure

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -43,7 +43,8 @@ spec:
                     "-ip_address_types=PRIVATE",
                     "-credential_file=/secrets/cloudsql/credentials.json",
                     "-term_timeout=30s",
-                    "-verbose=false"]
+                    "-verbose=false",
+                    "-log_debug_stdout=true"]
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -43,8 +43,7 @@ spec:
                     "-ip_address_types=PRIVATE",
                     "-credential_file=/secrets/cloudsql/credentials.json",
                     "-term_timeout=30s",
-                    "-verbose=false",
-                    "-log_debug_stdout=true"]
+                    "-verbose=false"]
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false


### PR DESCRIPTION
# What and why?
Non-error logs on GCP for cronjobs were being written to stderr instead of stdout. This changes the curl command to use the -s (--silent) parameter to quieten these logs

# How to test?
Run performance environment and check the logs. Make sure the [error logs](https://console.cloud.google.com/logs/query;query=severity%3DERROR%0AlogName%3D%22projects%2Fras-rm-performance-20220908%2Flogs%2Fstderr%22%0AtextPayload%3D%22%20%20%25%20Total%20%20%20%20%25%20Received%20%25%20Xferd%20%20Average%20Speed%20%20%20Time%20%20%20%20Time%20%20%20%20%20Time%20%20Current%22;cursorTimestamp=2024-09-10T09:00:01.059783081Z;duration=P14D?project=ras-rm-performance-20220908&rapt=AEjHL4OwIU9GpNc42eeogr7Yg0ygLLe60PdHIp-HXJ3UePZhK01MVwPgPKjnXT1KFu0BzXUmu_z7nU4uvwAIFgenmeiSsfAkUw0cJzLaik-ZYIO22_BJZYM&pli=1) for the party schedulers aren't appearing.

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-1222)