### PR TITLE
RAS-1228: Bug: Party service workers getting 139 SIGSEGV errors and restarting

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.2
+version: 2.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.2
+appVersion: 2.5.3

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -26,7 +26,7 @@ logger = structlog.wrap_logger(logging.getLogger(__name__))
 
 
 @with_query_only_db_session
-def get_business_by_ref(ref, session):
+def get_business_by_ref(ref, session, retrieve_associations=True):
     """
     Get a Business by its unique business reference
 
@@ -41,7 +41,7 @@ def get_business_by_ref(ref, session):
         raise NotFound("Business with reference does not exist.")
 
     return unified_buisness_party_functions.to_unified_dict(
-        business, collection_exercise_id=None, attributes_required=True
+        business, collection_exercise_id=None, attributes_required=True, retrieve_associations=retrieve_associations
     )
 
 

--- a/ras_party/controllers/business_controller.py
+++ b/ras_party/controllers/business_controller.py
@@ -5,6 +5,7 @@ import structlog
 from flask import current_app
 from werkzeug.exceptions import BadRequest, NotFound
 
+from ras_party import unified_buisness_party_functions
 from ras_party.controllers.queries import (
     query_business_attributes,
     query_business_attributes_by_collection_exercise,
@@ -39,7 +40,9 @@ def get_business_by_ref(ref, session):
         logger.info("Business with reference does not exist.", ru_ref=ref)
         raise NotFound("Business with reference does not exist.")
 
-    return business.to_party_dict()
+    return unified_buisness_party_functions.to_unified_dict(
+        business, collection_exercise_id=None, attributes_required=True
+    )
 
 
 @with_query_only_db_session
@@ -60,7 +63,7 @@ def get_businesses_by_ids(party_uuids, session):
             raise BadRequest(f"'{party_uuid}' is not a valid UUID format for property 'id'")
 
     businesses = query_businesses_by_party_uuids(party_uuids, session)
-    return [business.to_business_summary_dict() for business in businesses]
+    return [unified_buisness_party_functions.to_unified_dict(business) for business in businesses]
 
 
 @with_query_only_db_session
@@ -126,10 +129,14 @@ def get_business_by_id(party_uuid, session, verbose=False, collection_exercise_i
         logger.info("Business with id does not exist", party_uuid=party_uuid)
         raise NotFound("Business with party id does not exist")
 
-    if verbose:
-        return business.to_business_dict(collection_exercise_id=collection_exercise_id)
+    unified_dict = unified_buisness_party_functions.to_unified_dict(
+        business, collection_exercise_id=collection_exercise_id, attributes_required=True
+    )
 
-    return business.to_business_summary_dict(collection_exercise_id=collection_exercise_id)
+    if verbose:
+        return dict(unified_dict, **unified_dict["attributes"])
+
+    return unified_buisness_party_functions.to_unified_dict(business, collection_exercise_id=collection_exercise_id)
 
 
 @with_db_session

--- a/ras_party/controllers/party_controller.py
+++ b/ras_party/controllers/party_controller.py
@@ -4,6 +4,7 @@ import structlog
 from flask import current_app
 from werkzeug.exceptions import BadRequest, Conflict, NotFound
 
+from ras_party import unified_buisness_party_functions
 from ras_party.controllers.queries import (
     query_business_attributes_by_sample_summary_id,
     query_business_by_party_uuid,
@@ -93,13 +94,17 @@ def get_party_by_id(sample_unit_type, party_id, session):
         if not business:
             logger.info("Business with id does not exist", business_id=party_id, status=404)
             raise NotFound("Business with id does not exist")
-        return business.to_party_dict()
+        return unified_buisness_party_functions.to_unified_dict(
+            business, collection_exercise_id=None, attributes_required=True
+        )
     elif sample_unit_type == Respondent.UNIT_TYPE:
         respondent = query_respondent_by_party_uuid(party_id, session)
         if not respondent:
             logger.info("Respondent with id does not exist", respondent_id=party_id, status=404)
             raise NotFound("Respondent with id does not exist")
-        return respondent.to_party_dict()
+        return unified_buisness_party_functions.to_unified_dict(
+            respondent, collection_exercise_id=None, attributes_required=True
+        )
     else:
         logger.info("Invalid sample unit type", type=sample_unit_type)
         raise BadRequest(f"{sample_unit_type} is not a valid value for sampleUnitType. Must be one of ['B', 'BI']")

--- a/ras_party/models/model_functions.py
+++ b/ras_party/models/model_functions.py
@@ -1,0 +1,40 @@
+import logging
+
+import structlog
+from werkzeug.exceptions import BadRequest
+
+from ras_party.models import models
+
+logger = structlog.wrap_logger(logging.getLogger(__name__))
+
+
+def get_respondents_associations(respondents):
+    associations = []
+    for business_respondent in respondents:
+        respondent_dict = {
+            "partyId": business_respondent.respondent.party_uuid,
+            "businessRespondentStatus": business_respondent.respondent.status.name,
+        }
+        enrolments = business_respondent.enrolment
+        respondent_dict["enrolments"] = []
+        for enrolment in enrolments:
+            enrolments_dict = {
+                "surveyId": enrolment.survey_id,
+                "enrolmentStatus": models.EnrolmentStatus(enrolment.status).name,
+            }
+            respondent_dict["enrolments"].append(enrolments_dict)
+        associations.append(respondent_dict)
+    return associations
+
+
+def get_attributes_for_collection_exercise(model_attributes, collection_exercise_id=None):
+    if collection_exercise_id:
+        for attributes in model_attributes.attributes:
+            if attributes.collection_exercise == collection_exercise_id:
+                return attributes
+
+    try:
+        return next((attributes for attributes in model_attributes.attributes if attributes.collection_exercise))
+    except StopIteration:
+        logger.error("No active attributes for business", reference=model_attributes.business_ref, status=400)
+        raise BadRequest("Business with reference does not have any active attributes.")

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -19,8 +19,8 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.types import Enum
-from werkzeug.exceptions import BadRequest
 
+from ras_party.models import model_functions
 from ras_party.support.util import filter_falsey_values, partition_dict
 
 Base = declarative_base()
@@ -97,64 +97,6 @@ class Business(Base):
         ba.name = name
         ba.trading_as = trading_as
 
-    @staticmethod
-    def _get_respondents_associations(respondents):
-        associations = []
-        for business_respondent in respondents:
-            respondent_dict = {
-                "partyId": business_respondent.respondent.party_uuid,
-                "businessRespondentStatus": business_respondent.respondent.status.name,
-            }
-            enrolments = business_respondent.enrolment
-            respondent_dict["enrolments"] = []
-            for enrolment in enrolments:
-                enrolments_dict = {
-                    "surveyId": enrolment.survey_id,
-                    "enrolmentStatus": EnrolmentStatus(enrolment.status).name,
-                }
-                respondent_dict["enrolments"].append(enrolments_dict)
-            associations.append(respondent_dict)
-        return associations
-
-    def to_business_dict(self, collection_exercise_id=None):
-        """
-        Gets a dict that contains both summary data and collection exercise data.  The collection exercise data will be
-        for either the specified one if supplied, or the most recent one if not supplied
-
-        :param collection_exercise_id: A collection exercise uuid
-        :return: A dict containing both the summary data and business attributes for the business
-        :rtype: dict
-        """
-        d = self.to_business_summary_dict()
-        attributes = self._get_attributes_for_collection_exercise(collection_exercise_id)
-        return dict(d, **attributes.attributes)
-
-    def to_business_summary_dict(self, collection_exercise_id=None):
-        attributes = self._get_attributes_for_collection_exercise(collection_exercise_id)
-        d = {
-            "id": self.party_uuid,
-            "sampleUnitRef": self.business_ref,
-            "sampleUnitType": self.UNIT_TYPE,
-            "sampleSummaryId": attributes.sample_summary_id,
-            "name": attributes.attributes.get("name"),
-            "trading_as": attributes.attributes.get("trading_as"),
-            "associations": self._get_respondents_associations(self.respondents),
-        }
-        return d
-
-    def to_party_dict(self):
-        attributes = self._get_attributes_for_collection_exercise()
-        return {
-            "id": self.party_uuid,
-            "sampleUnitRef": self.business_ref,
-            "sampleUnitType": self.UNIT_TYPE,
-            "sampleSummaryId": attributes.sample_summary_id,
-            "attributes": attributes.attributes,
-            "name": attributes.attributes.get("name"),
-            "trading_as": attributes.attributes.get("trading_as"),
-            "associations": self._get_respondents_associations(self.respondents),
-        }
-
     def to_post_response_dict(self):
         return {
             "id": self.party_uuid,
@@ -164,20 +106,8 @@ class Business(Base):
             "attributes": self.attributes[-1].attributes,
             "name": self.attributes[-1].name,
             "trading_as": self.attributes[-1].trading_as,
-            "associations": self._get_respondents_associations(self.respondents),
+            "associations": model_functions.get_respondents_associations(self.respondents),
         }
-
-    def _get_attributes_for_collection_exercise(self, collection_exercise_id=None):
-        if collection_exercise_id:
-            for attributes in self.attributes:
-                if attributes.collection_exercise == collection_exercise_id:
-                    return attributes
-
-        try:
-            return next((attributes for attributes in self.attributes if attributes.collection_exercise))
-        except StopIteration:
-            logger.error("No active attributes for business", reference=self.business_ref, status=400)
-            raise BadRequest("Business with reference does not have any active attributes.")
 
 
 class BusinessAttributes(Base):

--- a/ras_party/unified_buisness_party_functions.py
+++ b/ras_party/unified_buisness_party_functions.py
@@ -1,0 +1,18 @@
+from ras_party.models import model_functions
+
+
+def to_unified_dict(model, collection_exercise_id=None, attributes_required=False):
+    attributes = model_functions.get_attributes_for_collection_exercise(model, collection_exercise_id)
+    unified_dict = {
+        "id": model.party_uuid,
+        "sampleUnitRef": model.business_ref,
+        "sampleUnitType": model.UNIT_TYPE,
+        "sampleSummaryId": attributes.sample_summary_id,
+        "name": attributes.attributes.get("name"),
+        "trading_as": attributes.attributes.get("trading_as"),
+        "associations": model_functions.get_respondents_associations(model.respondents),
+    }
+    if attributes_required:
+        unified_dict["attributes"] = attributes.attributes
+
+    return unified_dict

--- a/ras_party/unified_buisness_party_functions.py
+++ b/ras_party/unified_buisness_party_functions.py
@@ -1,7 +1,7 @@
 from ras_party.models import model_functions
 
 
-def to_unified_dict(model, collection_exercise_id=None, attributes_required=False):
+def to_unified_dict(model, collection_exercise_id=None, attributes_required=False, retrieve_associations=True):
     attributes = model_functions.get_attributes_for_collection_exercise(model, collection_exercise_id)
     unified_dict = {
         "id": model.party_uuid,
@@ -10,9 +10,10 @@ def to_unified_dict(model, collection_exercise_id=None, attributes_required=Fals
         "sampleSummaryId": attributes.sample_summary_id,
         "name": attributes.attributes.get("name"),
         "trading_as": attributes.attributes.get("trading_as"),
-        "associations": model_functions.get_respondents_associations(model.respondents),
     }
     if attributes_required:
         unified_dict["attributes"] = attributes.attributes
+    if retrieve_associations:
+        unified_dict["associations"] = model_functions.get_respondents_associations(model.respondents)
 
     return unified_dict

--- a/ras_party/views/business_view.py
+++ b/ras_party/views/business_view.py
@@ -82,7 +82,7 @@ def get_business_by_ref(ref):
 @business_view.route("/businesses/ref/reporting-unit-only/<ref>", methods=["GET"])
 def get_business_by_ref_only(ref):
     # This endpoint will retrieve the reporting unit only and not the associations.
-    business = business_controller.get_business_by_ref(ref, True)
+    business = business_controller.get_business_by_ref(ref, retrieve_associations=True)
     return jsonify(business)
 
 

--- a/ras_party/views/business_view.py
+++ b/ras_party/views/business_view.py
@@ -79,6 +79,13 @@ def get_business_by_ref(ref):
     return jsonify(business)
 
 
+@business_view.route("/businesses/ref/reporting-unit-only/<ref>", methods=["GET"])
+def get_business_by_ref_only(ref):
+    # This endpoint will retrieve the reporting unit only and not the associations.
+    business = business_controller.get_business_by_ref(ref, True)
+    return jsonify(business)
+
+
 @business_view.route("/businesses/sample/link/<sample>", methods=["PUT"])
 def put_business_attributes_ce(sample):
     payload = request.get_json() or {}


### PR DESCRIPTION
# What and why?
There have been a lot of 139 SIGSEGV errors and restarting by the service. The main culprit appears to be the way the calls are being handled and data retrieval of the associations. Due to the complexity of the interconnections between the services, it wasn't possible to separate the calls to associations. There needs to be further investigation into what services are calling the endpoints and whether they actually need the associations.

This code change extracts out the various data dictionaries used by the business and party into one unified dictionary. 

A new endpoint has been added that when called will only not bring back associations. I think this is the way to goto to help minimise the amount of calls being made.

# How to test?

1. Run unit tests 
2. Deploy this along with https://github.com/ONSdigital/response-operations-ui/pull/963 to your dev space
3. Run acceptance tests
4. Run checks to ensure that a CE can be created and linked to a business, that all related information is pulled for a business in from the reporting unit page (via the reporting search page), that the respondent data is being pulled correctly, messages can be sent and read correctly in rOps
5. In Frontstage, just a general regression check to check everything is working correctly. 

# Jira
https://jira.ons.gov.uk/browse/RAS-1228