### PR TITLE
Refactor email token decoding

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -172,11 +172,11 @@
         },
         "flask-cors": {
             "hashes": [
-                "sha256:eeb69b342142fdbf4766ad99357a7f3876a2ceb77689dc10ff912aac06c389e4",
-                "sha256:f2a704e4458665580c074b714c4627dd5a306b333deb9074d0b1794dfa2fb677"
+                "sha256:5aadb4b950c4e93745034594d9f3ea6591f734bb3662e16e255ffbf5e89c88ef",
+                "sha256:b9e307d082a9261c100d8fb0ba909eec6a228ed1b60a8315fd85f783d61910bc"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==5.0.0"
         },
         "flask-httpauth": {
             "hashes": [
@@ -919,12 +919,12 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18",
-                "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8"
+                "sha256:02c9eb92b7d6c06f31a782811505d2157837cea66aaede3e217c7c27c039476c",
+                "sha256:34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.0.3"
+            "version": "==3.0.4"
         },
         "zope.event": {
             "hashes": [

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.3
+version: 2.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.3
+appVersion: 2.5.4

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.2
+version: 2.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.2
+appVersion: 2.5.3

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -408,16 +408,14 @@ def decode_token(token):
 
 
 @with_query_only_db_session
-def verify_token(token, session):
+def verify_respondent_by_email(email, session):
     """
     Verify the email token and check if that respondent exists.
-    :param token: The email token for verification
+    :param email: The email token for verification
     :param session: Database session
     :return: Verification response
     """
-
-    email_address = decode_token(token)
-    respondent = query_respondent_by_email(email_address, session)
+    respondent = query_respondent_by_email(email, session)
     if not respondent:
         logger.info("Respondent with Email from token does not exist")
         raise NotFound("Respondent does not exist")
@@ -714,24 +712,22 @@ def notify_change_account_status(payload, party_id: str, session):
 
 @transactional
 @with_db_session
-def put_email_verification(token, tran, session):
+def put_email_verification(email, tran, session):
     """
     Verify email address, this method can be reached when registering or updating email address
-    :param token:
+    :param email:
     :param tran:
     :param session: db session
     :return: Verified respondent details
     """
-    logger.info("Attempting to verify email", token=token)
+    logger.info("Attempting to verify email", email=email)
 
-    email_address = decode_token(token)
-
-    respondent = query_respondent_by_email(email_address, session)
+    respondent = query_respondent_by_email(email, session)
 
     if not respondent:
         logger.info("Attempting to find respondent by pending email address")
         # When changing contact details, unverified new email is in pending_email_address
-        respondent = query_respondent_by_pending_email(email_address, session)
+        respondent = query_respondent_by_pending_email(email, session)
 
         if respondent:
             update_verified_email_address(respondent, tran)
@@ -757,7 +753,7 @@ def put_email_verification(token, tran, session):
             )
 
         # We set the user as verified on the OAuth2 server.
-        set_user_verified(email_address)
+        set_user_verified(email)
 
     return respondent.to_respondent_with_associations_dict()
 

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -393,7 +393,7 @@ def decode_token(token):
     """
     Decode the email verification token.
     :param token: The email token to decode
-    :return: The decoded email address
+    :return: Email address associated with decoded token
     """
     duration = current_app.config["EMAIL_TOKEN_EXPIRY"]
     try:

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -410,7 +410,7 @@ def decode_token(token):
 @with_query_only_db_session
 def verify_token(token, session):
     """
-    Verify the token and check if the respondent exists.
+    Verify the email token and check if that respondent exists.
     :param token: The email token for verification
     :param session: Database session
     :return: Verification response

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -720,7 +720,6 @@ def put_email_verification(email, tran, session):
     :param session: db session
     :return: Verified respondent details
     """
-    logger.info("Attempting to verify email", email=email)
 
     respondent = query_respondent_by_email(email, session)
 

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -410,8 +410,8 @@ def decode_token(token):
 @with_query_only_db_session
 def verify_respondent_by_email(email, session):
     """
-    Verify the email token and check if that respondent exists.
-    :param email: The email token for verification
+    Verify respondent by email address
+    :param email: The email for verification
     :param session: Database session
     :return: Verification response
     """

--- a/ras_party/controllers/account_controller.py
+++ b/ras_party/controllers/account_controller.py
@@ -391,8 +391,8 @@ def _send_account_email_changed_notification(email_address, new_email_address, r
 
 def decode_token(token):
     """
-    Decode the email verification token outside the session context.
-    :param token: The token to decode
+    Decode the email verification token.
+    :param token: The email token to decode
     :return: The decoded email address
     """
     duration = current_app.config["EMAIL_TOKEN_EXPIRY"]

--- a/ras_party/views/account_view.py
+++ b/ras_party/views/account_view.py
@@ -39,7 +39,8 @@ def put_respondent_by_email():
 
 @account_view.route("/tokens/verify/<token>", methods=["GET"])
 def get_verify_token(token):
-    response = account_controller.verify_token(token)
+    email = account_controller.decode_token(token)
+    response = account_controller.verify_respondent_by_email(email)
     return make_response(jsonify(response), 200)
 
 
@@ -66,7 +67,8 @@ def post_respondent():
 
 @account_view.route("/emailverification/<token>", methods=["PUT"])
 def put_email_verification(token):
-    response = account_controller.put_email_verification(token)
+    email = account_controller.decode_token(token)
+    response = account_controller.put_email_verification(email)
     return make_response(jsonify(response), 200)
 
 

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1096,7 +1096,8 @@ class TestRespondents(PartyTestClient):
             "ras_party.support.session_decorator.current_app.db"
         ) as db:
             token = generate_email_token("test@example.test")
-            account_controller.verify_token(token)
+            email = account_controller.decode_token(token)
+            account_controller.verify_respondent_by_email(email)
             query.assert_called_once_with("test@example.test", db.session())
 
     def test_put_respondent_email_returns_400_when_no_email(self):
@@ -1214,7 +1215,8 @@ class TestRespondents(PartyTestClient):
             "ras_party.support.session_decorator.current_app.db"
         ) as db:
             token = self.generate_valid_token_from_email("test@example.test")
-            account_controller.put_email_verification(token)
+            email = account_controller.decode_token(token)
+            account_controller.put_email_verification(email)
             query.assert_called_once_with("test@example.test", db.session())
 
     def test_token_removed_on_email_update(self):


### PR DESCRIPTION
# What and why?
When put_email_verification or verify_token encounter an exception during the decoding of the email token, it is raised within the session and causes incorrect logging and session rollbacks. 

This PR moves the decoding of the email token outside of the session context for both functions and reduced duplicate code within the functions. 

Flask-cors also had a vulnerability which has been updated on this pr. 
# How to test?
Ensure email verification still works correctly when updating or registering an email and the calls to the party service no longer contain session rollbacks or incorrect logging when an exception is thrown. 
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-1262