### PR TITLE
RAS-1289 Update the way claims is determined in the party service

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.3
+version: 2.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.3
+appVersion: 2.5.4

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.2
+version: 2.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.2
+appVersion: 2.5.3

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.4
+version: 2.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.4
+appVersion: 2.5.5

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -599,6 +599,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: survey_id
+          in: query
+          required: true
+          description: The UUID of the survey
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: The information has been retrieved

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -71,16 +71,6 @@ def get_respondents_by_name_and_email(first_name, last_name, email, page, limit,
     }
 
 
-def get_respondent_by_party_uuid(party_uuid: UUID, session: session) -> Respondent:
-    try:
-        uuid.UUID(party_uuid)
-    except ValueError:
-        raise BadRequest(f"'{party_uuid}' is not a valid UUID")
-
-    respondent = query_respondent_by_party_uuid(party_uuid, session)
-    return respondent
-
-
 @with_query_only_db_session
 def get_respondent_by_id(respondent_id, session):
     """
@@ -260,7 +250,7 @@ def get_respondents_by_survey_and_business_id(survey_id: UUID, business_id: UUID
 
 @with_query_only_db_session
 def is_user_enrolled(party_uuid: UUID, business_id: UUID, survey_id: UUID, session: session) -> bool:
-    respondent = get_respondent_by_party_uuid(party_uuid, session)
+    respondent = query_respondent_by_party_uuid(party_uuid, session)
 
     if respondent and respondent.status == RespondentStatus.ACTIVE:
         enrolment = query_enrolment_by_survey_business_respondent(respondent.id, business_id, survey_id, session)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -117,8 +117,8 @@ def validate_respondent_claim():
     business_id = request.args.get("business_id")
     survey_id = request.args.get("survey_id")
 
-    if not business_id or not party_uuid or not survey_id:
-        raise BadRequest("party_uuid, business id and survey_id are required")
+    if not (is_valid_uuid4(party_uuid) and is_valid_uuid4(business_id) and is_valid_uuid4(survey_id)):
+        return make_response("Bad request, party_uuid, business or survey id not UUID", 400)
 
     if respondent_controller.is_user_enrolled(party_uuid, business_id, survey_id):
         return make_response("Valid", 200)
@@ -130,8 +130,8 @@ def validate_respondent_claim():
 def get_respondents_by_business_and_survey_id(business_id: UUID, survey_id: UUID) -> Response:
     """Gets a list of Respondents enrolled in a survey for a specified business"""
 
-    if is_valid_uuid4(survey_id) and is_valid_uuid4(business_id):
-        respondents = respondent_controller.get_respondents_by_survey_and_business_id(survey_id, business_id)
-        return make_response(respondents, 200)
-    else:
+    if not (is_valid_uuid4(survey_id) and is_valid_uuid4(business_id)):
         return make_response("Bad request, business or survey id not UUID", 400)
+
+    respondents = respondent_controller.get_respondents_by_survey_and_business_id(survey_id, business_id)
+    return make_response(respondents, 200)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -113,16 +113,14 @@ def validate_respondent_claim():
     in client services. There is an argument to use a 403 on invalid claims , but that should be a status on the
     resource not the state of the returned data and so that's stretching the use of http status codes somewhat
     """
-    respondent_id = request.args.get("respondent_id", default="").strip()
-    business_id = request.args.get("business_id", default="").strip()
+    party_uuid = request.args.get("respondent_id")
+    business_id = request.args.get("business_id")
+    survey_id = request.args.get("survey_id")
 
-    if not business_id or not respondent_id:
-        logger.info(
-            "either respondent id or business id is missing", respondent_id=respondent_id, business_id=business_id
-        )
-        raise BadRequest("respondent id and business id is required")
+    if not business_id or not party_uuid or not survey_id:
+        raise BadRequest("party_uuid, business id and survey_id are required")
 
-    if respondent_controller.does_user_have_claim(respondent_id, business_id):
+    if respondent_controller.is_user_enrolled(party_uuid, business_id, survey_id):
         return make_response("Valid", 200)
 
     return make_response("Invalid", 200)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1692,6 +1692,14 @@ class TestRespondents(PartyTestClient):
             expected_result="Valid",
         )
 
+    def test_validate_claim_invalid_respondent_id(self):
+        self.validate_respondent_claim(
+            respondent_id="invalid",
+            business_id=DEFAULT_BUSINESS_UUID,
+            survey_id=DEFAULT_SURVEY_UUID,
+            expected_status=400,
+        )
+
     def test_validate_claim_returns_invalid_if_respondent_does_not_have_a_claim_on_specific_business(self):
         self.populate_with_respondent(respondent=self.mock_respondent_with_id_active)
         self.populate_with_business()
@@ -1701,7 +1709,7 @@ class TestRespondents(PartyTestClient):
 
         self.validate_respondent_claim(
             respondent_id=DEFAULT_RESPONDENT_UUID,
-            business_id="ADifferentBusiness",
+            business_id="feb28732-fa48-4f6d-802b-65e1215837b0",
             survey_id=DEFAULT_SURVEY_UUID,
             expected_status=200,
             expected_result="Invalid",


### PR DESCRIPTION
# What and why?
This PR updates how claims are processed and introduces survey_id in the check. This is part of a larger piece of reducing the amount of 139 crashes, at present get_respondent_by_id is doing more that what it should and by calling to_respondent_with_associations_dict() causing considerable overhead leading to timeouts. I can't remove get_respondent_by_id or the dict it is generating, but I can move the functionality to a cleaner function which just returns the repondent and then make enrolment checks cleaner and far more efficient


# How to test?
Test in conjunction with https://github.com/ONSdigital/ras-secure-message/pull/428, trying sending a new email via the survey help route, the account help route and replying to an existing thread. Reply and create a new message in ROPs as well
# Jira
