### PR TITLE
RAS-1350 Create enrolment end point for party

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731
+	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 73655
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8 --exclude=./scripts
 
 lint-check:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731
+	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 73655
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8 --exclude=./scripts

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 73655
+	pipenv check -i 42194 -i 70612 -i 70624 -i 72731
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8 --exclude=./scripts
 
 lint-check:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 73655
+	pipenv check -i 42194 -i 70612 -i 70624 -i 72731
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8 --exclude=./scripts

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.9
+version: 2.5.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.9
+appVersion: 2.5.10

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -823,12 +823,20 @@ paths:
           description: The password reset counter has been reset
         404:
           description: The respondent does not exist
-  /enrolments:
+  /enrolments/respondent/{party_uuid}:
     get:
       tags:
         - enrolments
       summary: get enrolment details
       description: returns a list of all enrolments that match given parameters
+      parameters:
+        - name: party_uuid
+          in: path
+          required: true
+          description: The UUID of the respondent
+          schema:
+            type: string
+            format: uuid
       responses:
         200:
           description: list of dict enrolments

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,8 @@ tags:
     description: Respondent endpoints
   - name: businesses
     description: Business endpoints
+  - name: enrolments
+    description: enrolments endpoints
   - name: info
     description: Information endpoints
   - name: misc
@@ -821,6 +823,37 @@ paths:
           description: The password reset counter has been reset
         404:
           description: The respondent does not exist
+  /enrolments:
+    get:
+      tags:
+        - enrolments
+      summary: get enrolment details
+      description: returns a list of all enrolments that match given parameters
+      responses:
+        200:
+          description: list of dict enrolments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    business_id:
+                      type: string
+                      format: uuid
+                    respondent_id:
+                      type: integer
+                    status:
+                      type: string
+                      example: ENABLED
+                    survey_id:
+                      type: string
+                      format: uuid
+        400:
+          description: Missing of malformed parameters
+        404:
+          description: Respondent doesn't exist
   /batch/respondents:
     delete:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -850,8 +850,6 @@ paths:
                     business_id:
                       type: string
                       format: uuid
-                    respondent_id:
-                      type: integer
                     status:
                       type: string
                       example: ENABLED

--- a/ras_party/controllers/enrolments_controller.py
+++ b/ras_party/controllers/enrolments_controller.py
@@ -6,8 +6,8 @@ from flask import session
 from sqlalchemy.orm.exc import NoResultFound
 
 from ras_party.controllers.queries import (
-    query_enrolments_by_parameters,
     query_respondent_by_party_uuid,
+    query_respondent_enrolments,
 )
 from ras_party.models.models import Enrolment
 from ras_party.support.session_decorator import with_query_only_db_session
@@ -16,18 +16,15 @@ logger = structlog.wrap_logger(logging.getLogger(__name__))
 
 
 @with_query_only_db_session
-def enrolments_by_parameters(
-    session: session, party_uuid: UUID = None, business_id: UUID = None, survey_id: UUID = None, status: int = None
+def respondent_enrolments(
+    session: session, party_uuid: UUID, business_id: UUID = None, survey_id: UUID = None, status: int = None
 ) -> list[Enrolment]:
     """
-    returns a list of Enrolments based on provided parameters
+    returns a list of respondent Enrolments. Business_id, survey_id and status can also be added as conditions
     """
 
-    if party_uuid:
-        respondent = query_respondent_by_party_uuid(party_uuid, session)
-        if not respondent:
-            raise NoResultFound
+    respondent = query_respondent_by_party_uuid(party_uuid, session)
+    if not respondent:
+        raise NoResultFound
 
-    respondent_id = respondent.id if party_uuid else None
-
-    return query_enrolments_by_parameters(session, respondent_id, business_id, survey_id, status)
+    return query_respondent_enrolments(session, respondent.id, business_id, survey_id, status)

--- a/ras_party/controllers/enrolments_controller.py
+++ b/ras_party/controllers/enrolments_controller.py
@@ -1,0 +1,33 @@
+import logging
+from uuid import UUID
+
+import structlog
+from flask import session
+from sqlalchemy.orm.exc import NoResultFound
+
+from ras_party.controllers.queries import (
+    query_enrolments_by_parameters,
+    query_respondent_by_party_uuid,
+)
+from ras_party.models.models import Enrolment
+from ras_party.support.session_decorator import with_query_only_db_session
+
+logger = structlog.wrap_logger(logging.getLogger(__name__))
+
+
+@with_query_only_db_session
+def enrolments_by_parameters(
+    session: session, party_uuid: UUID = None, business_id: UUID = None, survey_id: UUID = None, status: int = None
+) -> list[Enrolment]:
+    """
+    returns a list of Enrolments based on provided parameters
+    """
+
+    if party_uuid:
+        respondent = query_respondent_by_party_uuid(party_uuid, session)
+        if not respondent:
+            raise NoResultFound
+
+    respondent_id = respondent.id if party_uuid else None
+
+    return query_enrolments_by_parameters(session, respondent_id, business_id, survey_id, status)

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -643,3 +643,23 @@ def count_enrolment_by_survey_business(business_id, survey_id, session):
         .count()
     )
     return response
+
+
+def query_enrolments_by_parameters(
+    session: session, respondent_id: int = None, business_id: UUID = None, survey_id: UUID = None, status: int = None
+) -> list[Enrolment]:
+    """
+    Query to return a list of enrolments based on parameters
+    """
+    conditions = []
+
+    if respondent_id:
+        conditions.append(Enrolment.respondent_id == respondent_id)
+    if business_id:
+        conditions.append(Enrolment.business_id == business_id)
+    if survey_id:
+        conditions.append(Enrolment.survey_id == survey_id)
+    if status:
+        conditions.append(Enrolment.status == status)
+
+    return session.query(Enrolment).filter(and_(*conditions)).all()

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -645,21 +645,19 @@ def count_enrolment_by_survey_business(business_id, survey_id, session):
     return response
 
 
-def query_enrolments_by_parameters(
-    session: session, respondent_id: int = None, business_id: UUID = None, survey_id: UUID = None, status: int = None
+def query_respondent_enrolments(
+    session: session, respondent_id: int, business_id: UUID = None, survey_id: UUID = None, status: int = None
 ) -> list[Enrolment]:
     """
-    Query to return a list of enrolments based on parameters
+    Query to return a list of respondent Enrolments. Business_id, survey_id and status can also be added as conditions
     """
-    conditions = []
+    additional_conditions = []
 
-    if respondent_id:
-        conditions.append(Enrolment.respondent_id == respondent_id)
     if business_id:
-        conditions.append(Enrolment.business_id == business_id)
+        additional_conditions.append(Enrolment.business_id == business_id)
     if survey_id:
-        conditions.append(Enrolment.survey_id == survey_id)
+        additional_conditions.append(Enrolment.survey_id == survey_id)
     if status:
-        conditions.append(Enrolment.status == status)
+        additional_conditions.append(Enrolment.status == status)
 
-    return session.query(Enrolment).filter(and_(*conditions)).all()
+    return session.query(Enrolment).filter(and_(Enrolment.respondent_id == respondent_id, *additional_conditions)).all()

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -390,6 +390,14 @@ class Enrolment(Base):
         ),
     )
 
+    def to_dict(self) -> dict:
+        return {
+            "business_id": self.business_id,
+            "respondent_id": self.respondent_id,
+            "survey_id": self.survey_id,
+            "status": self.status.name,
+        }
+
 
 class PendingSurveys(Base):
     __tablename__ = "pending_surveys"

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -393,7 +393,6 @@ class Enrolment(Base):
     def to_dict(self) -> dict:
         return {
             "business_id": self.business_id,
-            "respondent_id": self.respondent_id,
             "survey_id": self.survey_id,
             "status": self.status.name,
         }

--- a/ras_party/views/enrolments_view.py
+++ b/ras_party/views/enrolments_view.py
@@ -1,0 +1,60 @@
+import logging
+
+import structlog
+from flask import Blueprint, Response, current_app, make_response, request
+from flask_httpauth import HTTPBasicAuth
+from sqlalchemy.exc import DataError
+from sqlalchemy.orm.exc import NoResultFound
+from werkzeug.exceptions import BadRequest, NotFound
+
+from ras_party.controllers.enrolments_controller import enrolments_by_parameters
+
+logger = structlog.wrap_logger(logging.getLogger(__name__))
+enrolments_view = Blueprint("enrolments_view", __name__)
+auth = HTTPBasicAuth()
+
+
+@enrolments_view.before_request
+@auth.login_required
+def before_respondent_view():
+    pass
+
+
+@auth.get_password
+def get_pw(username):
+    config_username = current_app.config["SECURITY_USER_NAME"]
+    config_password = current_app.config["SECURITY_USER_PASSWORD"]
+    if username == config_username:
+        return config_password
+
+
+@enrolments_view.route("/enrolments", methods=["GET"])
+def get_enrolments() -> Response:
+    json = request.get_json()
+    party_uuid = json.get("party_uuid")
+    business_id = json.get("business_id")
+    survey_id = json.get("survey_id")
+    status = json.get("status")
+
+    if not (party_uuid or business_id or survey_id):
+        logger.error("No parameters passed to get_enrolments")
+        return BadRequest()
+
+    try:
+        enrolments = enrolments_by_parameters(
+            party_uuid=party_uuid, business_id=business_id, survey_id=survey_id, status=status
+        )
+    except NoResultFound:
+        logger.error(f"Respondent not found for party_uuid {party_uuid}")
+        return NotFound()
+    except DataError:
+        logger.error(
+            "Data error, enrolment search parameters are not valid",
+            party_uuid=party_uuid,
+            business_id=business_id,
+            survey_id=survey_id,
+            status=status,
+        )
+        return BadRequest()
+
+    return make_response([enrolment.to_dict() for enrolment in enrolments], 200)

--- a/run.py
+++ b/run.py
@@ -41,7 +41,7 @@ def create_app(config=None):
     app.register_blueprint(respondent_view, url_prefix="/party-api/v1")
     app.register_blueprint(batch_request, url_prefix="/party-api/v1")
     app.register_blueprint(pending_survey_view, url_prefix="/party-api/v1")
-    app.register_blueprint(enrolments_view, url_prefix="/party-api/v1")
+    app.register_blueprint(enrolments_view, url_prefix="/party-api/v1/enrolments")
     app.register_blueprint(info_view)
     app.register_blueprint(error_handlers.blueprint)
 

--- a/run.py
+++ b/run.py
@@ -29,6 +29,7 @@ def create_app(config=None):
     from ras_party.views.account_view import account_view
     from ras_party.views.batch_request import batch_request
     from ras_party.views.business_view import business_view
+    from ras_party.views.enrolments_view import enrolments_view
     from ras_party.views.info_view import info_view
     from ras_party.views.party_view import party_view
     from ras_party.views.pending_survey_view import pending_survey_view
@@ -40,6 +41,7 @@ def create_app(config=None):
     app.register_blueprint(respondent_view, url_prefix="/party-api/v1")
     app.register_blueprint(batch_request, url_prefix="/party-api/v1")
     app.register_blueprint(pending_survey_view, url_prefix="/party-api/v1")
+    app.register_blueprint(enrolments_view, url_prefix="/party-api/v1")
     app.register_blueprint(info_view)
     app.register_blueprint(error_handlers.blueprint)
 

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -444,3 +444,7 @@ class PartyTestClient(TestCase):
     def get_respondents_by_party_id(self, party_id):
         response = self.client.get(f"/party-api/v1/respondents/party_id/{party_id}", headers=self.auth_headers)
         return response
+
+    def get_enrolments(self, payload):
+        response = self.client.get("/party-api/v1/enrolments", json=payload, headers=self.auth_headers)
+        return response

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -445,6 +445,8 @@ class PartyTestClient(TestCase):
         response = self.client.get(f"/party-api/v1/respondents/party_id/{party_id}", headers=self.auth_headers)
         return response
 
-    def get_enrolments(self, payload):
-        response = self.client.get("/party-api/v1/enrolments", json=payload, headers=self.auth_headers)
+    def get_respondent_enrolments(self, party_id, payload={}):
+        response = self.client.get(
+            f"/party-api/v1/enrolments/respondent/{party_id}", json=payload, headers=self.auth_headers
+        )
         return response

--- a/test/test_enrolments_controller.py
+++ b/test/test_enrolments_controller.py
@@ -3,7 +3,7 @@ from test.party_client import PartyTestClient
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
-from ras_party.controllers.enrolments_controller import enrolments_by_parameters
+from ras_party.controllers.enrolments_controller import respondent_enrolments
 from ras_party.models.models import (
     Business,
     BusinessRespondent,
@@ -53,29 +53,14 @@ class TestEnrolments(PartyTestClient):
         self._add_enrolments()
 
     def test_get_enrolments_party_id(self):
-        enrolments = enrolments_by_parameters(party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
+        enrolments = respondent_enrolments(party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
 
         self.assertEqual(len(enrolments), 2)
         self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
         self.assertIn(str(enrolments[1].business_id), "98e2c9dd-a760-47dd-ba18-439fd5fb93a3")
 
-    def test_get_enrolments_business_id(self):
-        enrolments = enrolments_by_parameters(business_id="75d9af56-1225-4d43-b41d-1199f5f89daa")
-
-        self.assertEqual(len(enrolments), 2)
-        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
-        self.assertIn(str(enrolments[1].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
-
-    def test_get_enrolments_survey_id(self):
-        enrolments = enrolments_by_parameters(survey_id="9200d295-9d6e-41fe-b541-747ae67a279f")
-
-        self.assertEqual(len(enrolments), 3)
-        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertIn(str(enrolments[1].business_id), "af25c9d5-6893-4342-9d24-4b88509e965f")
-        self.assertIn(str(enrolments[2].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-
     def test_get_enrolments_party_id_and_business_id_and_survey_id(self):
-        enrolments = enrolments_by_parameters(
+        enrolments = respondent_enrolments(
             party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85",
             business_id="75d9af56-1225-4d43-b41d-1199f5f89daa",
             survey_id="9200d295-9d6e-41fe-b541-747ae67a279f",
@@ -87,7 +72,7 @@ class TestEnrolments(PartyTestClient):
         self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     def test_get_enrolments_party_id_enabled(self):
-        enrolments = enrolments_by_parameters(
+        enrolments = respondent_enrolments(
             party_uuid="5718649e-30bf-4c25-a2c0-aaa733e54ed6", status=EnrolmentStatus.ENABLED
         )
 
@@ -96,7 +81,7 @@ class TestEnrolments(PartyTestClient):
         self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     def test_get_enrolments_party_id_disabled(self):
-        enrolments = enrolments_by_parameters(
+        enrolments = respondent_enrolments(
             party_uuid="5718649e-30bf-4c25-a2c0-aaa733e54ed6", status=EnrolmentStatus.DISABLED
         )
 
@@ -106,21 +91,21 @@ class TestEnrolments(PartyTestClient):
 
     def test_get_enrolments_party_id_not_found_respondent(self):
         with self.assertRaises(NoResultFound):
-            enrolments_by_parameters(party_uuid="e6a016da-f7e8-4cb0-88da-9d34a7c1382a")
+            respondent_enrolments(party_uuid="e6a016da-f7e8-4cb0-88da-9d34a7c1382a")
 
     def test_get_enrolments_party_id_data_error(self):
         with self.assertRaises(DataError):
-            enrolments_by_parameters(party_uuid="malformed_id")
+            respondent_enrolments(party_uuid="malformed_id")
 
     @with_db_session
     def _add_enrolments(self, session):
         businesses = {}
 
-        for respondent_enrolments in respondents_enrolments:
-            respondent = Respondent(party_uuid=respondent_enrolments["respondent"])
+        for respondent_enrolment in respondents_enrolments:
+            respondent = Respondent(party_uuid=respondent_enrolment["respondent"])
             session.add(respondent)
 
-            for enrolment in respondent_enrolments["enrolment_details"]:
+            for enrolment in respondent_enrolment["enrolment_details"]:
                 if not (business := businesses.get(enrolment["business"])):
                     business = Business(party_uuid=enrolment["business"])
                     session.add(business)

--- a/test/test_enrolments_controller.py
+++ b/test/test_enrolments_controller.py
@@ -1,0 +1,138 @@
+from test.party_client import PartyTestClient
+
+from sqlalchemy.exc import DataError
+from sqlalchemy.orm.exc import NoResultFound
+
+from ras_party.controllers.enrolments_controller import enrolments_by_parameters
+from ras_party.models.models import (
+    Business,
+    BusinessRespondent,
+    Enrolment,
+    EnrolmentStatus,
+    Respondent,
+)
+from ras_party.support.session_decorator import with_db_session
+
+respondents_enrolments = [
+    {
+        "respondent": "b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85",
+        "enrolment_details": [
+            {
+                "business": "75d9af56-1225-4d43-b41d-1199f5f89daa",
+                "survey_id": "9200d295-9d6e-41fe-b541-747ae67a279f",
+                "status": EnrolmentStatus.ENABLED,
+            },
+            {
+                "business": "98e2c9dd-a760-47dd-ba18-439fd5fb93a3",
+                "survey_id": "c641f6ad-a5eb-4d82-a647-7cd586549bbc",
+                "status": EnrolmentStatus.ENABLED,
+            },
+        ],
+    },
+    {
+        "respondent": "5718649e-30bf-4c25-a2c0-aaa733e54ed6",
+        "enrolment_details": [
+            {
+                "business": "af25c9d5-6893-4342-9d24-4b88509e965f",
+                "survey_id": "9200d295-9d6e-41fe-b541-747ae67a279f",
+                "status": EnrolmentStatus.ENABLED,
+            },
+            {
+                "business": "75d9af56-1225-4d43-b41d-1199f5f89daa",
+                "survey_id": "9200d295-9d6e-41fe-b541-747ae67a279f",
+                "status": EnrolmentStatus.DISABLED,
+            },
+        ],
+    },
+]
+
+
+class TestEnrolments(PartyTestClient):
+
+    def setUp(self):
+        self._add_enrolments()
+
+    def test_get_enrolments_party_id(self):
+        enrolments = enrolments_by_parameters(party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
+
+        self.assertEqual(len(enrolments), 2)
+        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertIn(str(enrolments[1].business_id), "98e2c9dd-a760-47dd-ba18-439fd5fb93a3")
+
+    def test_get_enrolments_business_id(self):
+        enrolments = enrolments_by_parameters(business_id="75d9af56-1225-4d43-b41d-1199f5f89daa")
+
+        self.assertEqual(len(enrolments), 2)
+        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertIn(str(enrolments[1].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+
+    def test_get_enrolments_survey_id(self):
+        enrolments = enrolments_by_parameters(survey_id="9200d295-9d6e-41fe-b541-747ae67a279f")
+
+        self.assertEqual(len(enrolments), 3)
+        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertIn(str(enrolments[1].business_id), "af25c9d5-6893-4342-9d24-4b88509e965f")
+        self.assertIn(str(enrolments[2].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+
+    def test_get_enrolments_party_id_and_business_id_and_survey_id(self):
+        enrolments = enrolments_by_parameters(
+            party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85",
+            business_id="75d9af56-1225-4d43-b41d-1199f5f89daa",
+            survey_id="9200d295-9d6e-41fe-b541-747ae67a279f",
+        )
+
+        self.assertEqual(len(enrolments), 1)
+        self.assertIn(str(enrolments[0].respondent_id), "b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
+        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+
+    def test_get_enrolments_party_id_enabled(self):
+        enrolments = enrolments_by_parameters(
+            party_uuid="5718649e-30bf-4c25-a2c0-aaa733e54ed6", status=EnrolmentStatus.ENABLED
+        )
+
+        self.assertEqual(len(enrolments), 1)
+        self.assertIn(str(enrolments[0].business_id), "af25c9d5-6893-4342-9d24-4b88509e965f")
+        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+
+    def test_get_enrolments_party_id_disabled(self):
+        enrolments = enrolments_by_parameters(
+            party_uuid="5718649e-30bf-4c25-a2c0-aaa733e54ed6", status=EnrolmentStatus.DISABLED
+        )
+
+        self.assertEqual(len(enrolments), 1)
+        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+
+    def test_get_enrolments_party_id_not_found_respondent(self):
+        with self.assertRaises(NoResultFound):
+            enrolments_by_parameters(party_uuid="e6a016da-f7e8-4cb0-88da-9d34a7c1382a")
+
+    def test_get_enrolments_party_id_data_error(self):
+        with self.assertRaises(DataError):
+            enrolments_by_parameters(party_uuid="malformed_id")
+
+    @with_db_session
+    def _add_enrolments(self, session):
+        businesses = {}
+
+        for respondent_enrolments in respondents_enrolments:
+            respondent = Respondent(party_uuid=respondent_enrolments["respondent"])
+            session.add(respondent)
+
+            for enrolment in respondent_enrolments["enrolment_details"]:
+                if not (business := businesses.get(enrolment["business"])):
+                    business = Business(party_uuid=enrolment["business"])
+                    session.add(business)
+                    businesses[enrolment["business"]] = business
+
+                business_respondent = BusinessRespondent(business=business, respondent=respondent)
+                session.add(business_respondent)
+                session.flush()
+                enrolment = Enrolment(
+                    business_id=business.party_uuid,
+                    survey_id=enrolment["survey_id"],
+                    respondent_id=respondent.id,
+                    status=enrolment["status"],
+                )
+                session.add(enrolment)

--- a/test/test_enrolments_controller.py
+++ b/test/test_enrolments_controller.py
@@ -56,8 +56,8 @@ class TestEnrolments(PartyTestClient):
         enrolments = respondent_enrolments(party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
 
         self.assertEqual(len(enrolments), 2)
-        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertIn(str(enrolments[1].business_id), "98e2c9dd-a760-47dd-ba18-439fd5fb93a3")
+        self.assertEqual(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertEqual(str(enrolments[1].business_id), "98e2c9dd-a760-47dd-ba18-439fd5fb93a3")
 
     def test_get_enrolments_party_id_and_business_id_and_survey_id(self):
         enrolments = respondent_enrolments(
@@ -67,9 +67,9 @@ class TestEnrolments(PartyTestClient):
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertIn(str(enrolments[0].respondent_id), "b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
-        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0].respondent_id), "1")
+        self.assertEqual(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertEqual(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     def test_get_enrolments_party_id_enabled(self):
         enrolments = respondent_enrolments(
@@ -77,8 +77,8 @@ class TestEnrolments(PartyTestClient):
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertIn(str(enrolments[0].business_id), "af25c9d5-6893-4342-9d24-4b88509e965f")
-        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0].business_id), "af25c9d5-6893-4342-9d24-4b88509e965f")
+        self.assertEqual(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     def test_get_enrolments_party_id_disabled(self):
         enrolments = respondent_enrolments(
@@ -86,8 +86,8 @@ class TestEnrolments(PartyTestClient):
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertIn(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertIn(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertEqual(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     def test_get_enrolments_party_id_not_found_respondent(self):
         with self.assertRaises(NoResultFound):

--- a/test/test_enrolments_view.py
+++ b/test/test_enrolments_view.py
@@ -10,9 +10,9 @@ from ras_party.models.models import Enrolment, EnrolmentStatus
 
 class TestEnrolmentsView(PartyTestClient):
 
-    @patch("ras_party.views.enrolments_view.enrolments_by_parameters")
-    def test_get_enrolments(self, enrolments_by_parameters):
-        enrolments_by_parameters.return_value = [
+    @patch("ras_party.views.enrolments_view.respondent_enrolments")
+    def test_get_enrolments(self, respondent_enrolments):
+        respondent_enrolments.return_value = [
             Enrolment(
                 business_id="79af714a-ee1d-446c-9f39-763296ec1f05",
                 survey_id="38553552-7d08-42e4-b86b-06f158c4b95e",
@@ -20,12 +20,11 @@ class TestEnrolmentsView(PartyTestClient):
                 status=EnrolmentStatus.ENABLED,
             )
         ]
-        response = self.get_enrolments({"party_uuid": "b146f595-62a0-4d6d-ba88-ef40cffdf8a7"})
+        response = self.get_respondent_enrolments("b146f595-62a0-4d6d-ba88-ef40cffdf8a7")
 
         expected_response = [
             {
                 "business_id": "79af714a-ee1d-446c-9f39-763296ec1f05",
-                "respondent_id": 1,
                 "survey_id": "38553552-7d08-42e4-b86b-06f158c4b95e",
                 "status": "ENABLED",
             }
@@ -33,21 +32,21 @@ class TestEnrolmentsView(PartyTestClient):
 
         self.assertEqual(expected_response, json.loads(response.data))
 
-    @patch("ras_party.views.enrolments_view.enrolments_by_parameters")
-    def test_get_enrolments_not_found_respondent(self, enrolments_by_parameters):
-        enrolments_by_parameters.side_effect = NoResultFound
-        response = self.get_enrolments({"party_uuid": "707778b9-cdb0-467a-9585-ee06bca47e2c"})
+    @patch("ras_party.views.enrolments_view.respondent_enrolments")
+    def test_get_enrolments_not_found_respondent(self, respondent_enrolments):
+        respondent_enrolments.side_effect = NoResultFound
+        response = self.get_respondent_enrolments("707778b9-cdb0-467a-9585-ee06bca47e2c")
 
         self.assertEqual(404, response.status_code)
 
-    @patch("ras_party.views.enrolments_view.enrolments_by_parameters")
-    def test_get_enrolments_data_error(self, enrolments_by_parameters):
-        enrolments_by_parameters.side_effect = DataError("InvalidTextRepresentation", "party_uuid", "orig")
-        response = self.get_enrolments({"party_uuid": "malformed_id"})
+    @patch("ras_party.views.enrolments_view.respondent_enrolments")
+    def test_get_enrolments_data_error(self, respondent_enrolments):
+        respondent_enrolments.side_effect = DataError("InvalidTextRepresentation", "party_uuid", "orig")
+        response = self.get_respondent_enrolments("malformed_id")
 
         self.assertEqual(400, response.status_code)
 
     def test_get_enrolments_no_params(self):
-        response = self.get_enrolments({})
+        response = self.get_respondent_enrolments({})
 
         self.assertEqual(400, response.status_code)

--- a/test/test_enrolments_view.py
+++ b/test/test_enrolments_view.py
@@ -1,0 +1,53 @@
+import json
+from test.party_client import PartyTestClient
+from unittest.mock import patch
+
+from sqlalchemy.exc import DataError
+from sqlalchemy.orm.exc import NoResultFound
+
+from ras_party.models.models import Enrolment, EnrolmentStatus
+
+
+class TestEnrolmentsView(PartyTestClient):
+
+    @patch("ras_party.views.enrolments_view.enrolments_by_parameters")
+    def test_get_enrolments(self, enrolments_by_parameters):
+        enrolments_by_parameters.return_value = [
+            Enrolment(
+                business_id="79af714a-ee1d-446c-9f39-763296ec1f05",
+                survey_id="38553552-7d08-42e4-b86b-06f158c4b95e",
+                respondent_id=1,
+                status=EnrolmentStatus.ENABLED,
+            )
+        ]
+        response = self.get_enrolments({"party_uuid": "b146f595-62a0-4d6d-ba88-ef40cffdf8a7"})
+
+        expected_response = [
+            {
+                "business_id": "79af714a-ee1d-446c-9f39-763296ec1f05",
+                "respondent_id": 1,
+                "survey_id": "38553552-7d08-42e4-b86b-06f158c4b95e",
+                "status": "ENABLED",
+            }
+        ]
+
+        self.assertEqual(expected_response, json.loads(response.data))
+
+    @patch("ras_party.views.enrolments_view.enrolments_by_parameters")
+    def test_get_enrolments_not_found_respondent(self, enrolments_by_parameters):
+        enrolments_by_parameters.side_effect = NoResultFound
+        response = self.get_enrolments({"party_uuid": "707778b9-cdb0-467a-9585-ee06bca47e2c"})
+
+        self.assertEqual(404, response.status_code)
+
+    @patch("ras_party.views.enrolments_view.enrolments_by_parameters")
+    def test_get_enrolments_data_error(self, enrolments_by_parameters):
+        enrolments_by_parameters.side_effect = DataError("InvalidTextRepresentation", "party_uuid", "orig")
+        response = self.get_enrolments({"party_uuid": "malformed_id"})
+
+        self.assertEqual(400, response.status_code)
+
+    def test_get_enrolments_no_params(self):
+        response = self.get_enrolments({})
+
+        self.assertEqual(400, response.status_code)


### PR DESCRIPTION
# What and why?
This PR adds in an endpoint to retrieve enrolments, I have intentionally made it wider than it probably needs. The respondent-details endpoint which is causing us all the problems and unnecessarily builds enrolments in a very inefficient way is used indirectly in over 50 places across our microservices. Although I have looked at everyone, I can't confidently say exactly the requirements of these 2 end points until I start working individually on each, so I have made both more inclusive with the aim to harden afterwards. 

N.B there are also now places I can refactor using this approach in this repo, things like the claim end point can be removed, plus other functions I can plug into the query, I don't want to over stretch here. This is purely about getting 2 endpoints (this and the respondent one) which are clean and efficient and then migrating over in a controlled way

# How to test?
Deploy this PR and put some data into the system (acceptance tests are fine) Then hit the endpoint with different payloads and see what you get back, don't forget your basic auth (Username: admin, Passord: secret)
![Screenshot 2024-11-15 at 10 10 05](https://github.com/user-attachments/assets/18087fb2-9ecf-4a78-81de-5fc4fc0d9942)


# Jira
