### PR TITLE
Remove respondent dict and update test

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.10
+version: 2.5.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.10
+appVersion: 2.5.11

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.9
+version: 2.5.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.9
+appVersion: 2.5.10

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -322,22 +322,6 @@ class Respondent(Base):
             "password_reset_counter": self.password_reset_counter,
         }
 
-    def to_dict(self) -> dict:
-        return {
-            "id": self.id,
-            "party_uuid": self.party_uuid,
-            "status": RespondentStatus(self.status).name,
-            "email_address": self.email_address,
-            "pending_email_address": self.pending_email_address,
-            "first_name": self.first_name,
-            "last_name": self.last_name,
-            "telephone": self.telephone,
-            "created_on": self.created_on,
-            "mark_for_deletion": self.mark_for_deletion,
-            "password_verification_token": self.password_verification_token,
-            "password_reset_counter": self.password_reset_counter,
-        }
-
     def to_respondent_with_associations_dict(self):
         respondent_dict = self.to_respondent_dict()
         respondent_dict["associations"] = self._get_business_associations(self.businesses)

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -84,7 +84,7 @@ def get_respondent_by_party_id(party_id: UUID) -> Response:
 
     respondent = respondent_controller.get_respondent_by_party_id(party_id)
     if respondent:
-        return make_response(respondent.to_dict(), 200)
+        return make_response(respondent.to_respondent_dict(), 200)
 
     return make_response(f"respondent not found for party_id {party_id}", 404)
 

--- a/test/test_respondent_view.py
+++ b/test/test_respondent_view.py
@@ -53,9 +53,22 @@ class TestRespondentView(PartyTestClient):
 
         # Then a 200 is returned with the correct Respondent
         json_response = json.loads(response.data)
+        expected_response = {
+            "emailAddress": "email address",
+            "firstName": "first name",
+            "id": "7ab8f3b6-f436-400d-8911-335a61ec58e5",
+            "lastName": "last name",
+            "markForDeletion": None,
+            "password_reset_counter": None,
+            "password_verification_token": None,
+            "pendingEmailAddress": None,
+            "sampleUnitType": "BI",
+            "status": "ACTIVE",
+            "telephone": "telephone",
+        }
         respondent["status"] = "ACTIVE"  # The to_dict is returning the ResponseStatus name so this needs to be updated
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json_response, json_response | respondent)
+        self.assertEqual(json_response, expected_response)
 
     def test_get_respondents_by_party_id_invalid_uuid(self):
         # Given/When the end point is called with an invalid uuid for party_id


### PR DESCRIPTION
# What and why?
Whilst writing the new respondent end point a new dict was introduced. It was to not only sort out the structure, but to make the json more consistent, in reflection it is too aspirational to also fix at the same time, and the old one should be used

# How to test?
The good news is the only endpoint this is used by has no use by any other services yet, and that endpoint is now using a well tested dict. This basically doesn't need anything more than an eye ball
# Jira
