### PR TITLE
RAS-1378 Fix datetime deprecation warning on party service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ONSdigital/sdc-rmras

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.12
+version: 2.5.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.12
+appVersion: 2.5.13

--- a/ras_party/controllers/pending_survey_controller.py
+++ b/ras_party/controllers/pending_survey_controller.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from urllib.error import HTTPError
 
 import structlog
@@ -129,7 +129,7 @@ def delete_pending_surveys(session):
     Deletes all the existing pending surveys which have expired
     :param session A db session
     """
-    _expired_hrs = datetime.utcnow() - timedelta(seconds=float(current_app.config["EMAIL_TOKEN_EXPIRY"]))
+    _expired_hrs = datetime.now(UTC) - timedelta(seconds=float(current_app.config["EMAIL_TOKEN_EXPIRY"]))
     pending_shares = session.query(PendingSurveys).filter(PendingSurveys.time_shared < _expired_hrs)
     pending_shares.delete()
     logger.info("Deletion complete")
@@ -143,7 +143,7 @@ def get_unique_pending_surveys(is_transfer, session):
     :type is_transfer: bool
     :param session A db session
     """
-    _expired_hrs = datetime.utcnow() - timedelta(seconds=float(current_app.config["EMAIL_TOKEN_EXPIRY"]))
+    _expired_hrs = datetime.now(UTC) - timedelta(seconds=float(current_app.config["EMAIL_TOKEN_EXPIRY"]))
     pending_shares_ready_for_deletion = (
         session.query(PendingSurveys)
         .filter(PendingSurveys.time_shared < _expired_hrs)

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -1,7 +1,6 @@
 import enum
 import logging
 import uuid
-from datetime import UTC, datetime
 
 import structlog
 from jsonschema import Draft4Validator
@@ -18,6 +17,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.sql import func
 from sqlalchemy.types import Enum
 from werkzeug.exceptions import BadRequest
 
@@ -39,7 +39,7 @@ class Business(Base):
     attributes = relationship(
         "BusinessAttributes", backref="business", order_by="desc(BusinessAttributes.created_on)", lazy="joined"
     )
-    created_on = Column(DateTime, default=datetime.now(UTC))
+    created_on = Column(DateTime(timezone=True), default=func.now())
 
     @staticmethod
     def validate(json_packet, schema):
@@ -188,7 +188,7 @@ class BusinessAttributes(Base):
     sample_summary_id = Column(Text)
     collection_exercise = Column(Text)
     attributes = Column(JSONB)
-    created_on = Column(DateTime, default=datetime.now(UTC))
+    created_on = Column(DateTime(timezone=True), default=func.now())
     name = Column(Text)  # New columns placed at end of list in case code uses positional rather than named references
     trading_as = Column(Text)
     Index("attributes_name_idx", name)
@@ -232,9 +232,9 @@ class BusinessRespondent(Base):
     business_id = Column(UUID, ForeignKey("business.party_uuid"), primary_key=True)
     respondent_id = Column(Integer, ForeignKey("respondent.id"), primary_key=True)
     status = Column("status", Enum(BusinessRespondentStatus), default=BusinessRespondentStatus.ACTIVE)
-    effective_from = Column(DateTime, default=datetime.now(UTC))
-    effective_to = Column(DateTime)
-    created_on = Column(DateTime, default=datetime.now(UTC))
+    effective_from = Column(DateTime(timezone=True), default=func.now())
+    effective_to = Column(DateTime(timezone=True))
+    created_on = Column(DateTime(timezone=True), default=func.now())
 
     business = relationship("Business", back_populates="respondents", lazy="joined")
     respondent = relationship("Respondent", back_populates="businesses", lazy="joined")
@@ -257,7 +257,7 @@ class PendingEnrolment(Base):
     business_id = Column(UUID)
     survey_id = Column(UUID)
 
-    created_on = Column(DateTime, default=datetime.now(UTC))
+    created_on = Column(DateTime(timezone=True), default=func.now())
     respondent = relationship("Respondent")
     Index("pending_enrolment_case_idx", case_id)
 
@@ -279,7 +279,7 @@ class Respondent(Base):
     last_name = Column(Text)
     telephone = Column(Text)
     mark_for_deletion = Column(Boolean, default=False)
-    created_on = Column(DateTime, default=datetime.now(UTC))
+    created_on = Column(DateTime(timezone=True), default=func.now())
     password_verification_token = Column(Text)
     password_reset_counter = Column(Integer, default=0)
     pending_enrolment = relationship("PendingEnrolment", back_populates="respondent")
@@ -360,7 +360,7 @@ class Enrolment(Base):
     respondent_id = Column(Integer, primary_key=True)
     survey_id = Column(Text, primary_key=True)
     status = Column("status", Enum(EnrolmentStatus), default=EnrolmentStatus.PENDING)
-    created_on = Column(DateTime, default=datetime.now(UTC))
+    created_on = Column(DateTime(timezone=True), default=func.now())
 
     business_respondent = relationship("BusinessRespondent", back_populates="enrolment", lazy="joined")
     Index("enrolment_business_idx", business_id)
@@ -387,7 +387,7 @@ class PendingSurveys(Base):
     email_address = Column(Text, primary_key=True)
     business_id = Column(UUID, primary_key=True)
     survey_id = Column(Text, primary_key=True)
-    time_shared = Column(DateTime, default=datetime.now(UTC))
+    time_shared = Column(DateTime(timezone=True), default=func.now())
     shared_by = Column(UUID)
     batch_no = Column(UUID, default=uuid.uuid4)
     is_transfer = Column(Boolean, default=False)

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -1,7 +1,7 @@
-import datetime
 import enum
 import logging
 import uuid
+from datetime import UTC, datetime
 
 import structlog
 from jsonschema import Draft4Validator
@@ -39,7 +39,7 @@ class Business(Base):
     attributes = relationship(
         "BusinessAttributes", backref="business", order_by="desc(BusinessAttributes.created_on)", lazy="joined"
     )
-    created_on = Column(DateTime, default=datetime.datetime.utcnow)
+    created_on = Column(DateTime, default=datetime.now(UTC))
 
     @staticmethod
     def validate(json_packet, schema):
@@ -188,7 +188,7 @@ class BusinessAttributes(Base):
     sample_summary_id = Column(Text)
     collection_exercise = Column(Text)
     attributes = Column(JSONB)
-    created_on = Column(DateTime, default=datetime.datetime.utcnow)
+    created_on = Column(DateTime, default=datetime.now(UTC))
     name = Column(Text)  # New columns placed at end of list in case code uses positional rather than named references
     trading_as = Column(Text)
     Index("attributes_name_idx", name)
@@ -232,9 +232,9 @@ class BusinessRespondent(Base):
     business_id = Column(UUID, ForeignKey("business.party_uuid"), primary_key=True)
     respondent_id = Column(Integer, ForeignKey("respondent.id"), primary_key=True)
     status = Column("status", Enum(BusinessRespondentStatus), default=BusinessRespondentStatus.ACTIVE)
-    effective_from = Column(DateTime, default=datetime.datetime.utcnow)
+    effective_from = Column(DateTime, default=datetime.now(UTC))
     effective_to = Column(DateTime)
-    created_on = Column(DateTime, default=datetime.datetime.utcnow)
+    created_on = Column(DateTime, default=datetime.now(UTC))
 
     business = relationship("Business", back_populates="respondents", lazy="joined")
     respondent = relationship("Respondent", back_populates="businesses", lazy="joined")
@@ -257,7 +257,7 @@ class PendingEnrolment(Base):
     business_id = Column(UUID)
     survey_id = Column(UUID)
 
-    created_on = Column(DateTime, default=datetime.datetime.utcnow)
+    created_on = Column(DateTime, default=datetime.now(UTC))
     respondent = relationship("Respondent")
     Index("pending_enrolment_case_idx", case_id)
 
@@ -279,7 +279,7 @@ class Respondent(Base):
     last_name = Column(Text)
     telephone = Column(Text)
     mark_for_deletion = Column(Boolean, default=False)
-    created_on = Column(DateTime, default=datetime.datetime.utcnow)
+    created_on = Column(DateTime, default=datetime.now(UTC))
     password_verification_token = Column(Text)
     password_reset_counter = Column(Integer, default=0)
     pending_enrolment = relationship("PendingEnrolment", back_populates="respondent")
@@ -360,7 +360,7 @@ class Enrolment(Base):
     respondent_id = Column(Integer, primary_key=True)
     survey_id = Column(Text, primary_key=True)
     status = Column("status", Enum(EnrolmentStatus), default=EnrolmentStatus.PENDING)
-    created_on = Column(DateTime, default=datetime.datetime.utcnow)
+    created_on = Column(DateTime, default=datetime.now(UTC))
 
     business_respondent = relationship("BusinessRespondent", back_populates="enrolment", lazy="joined")
     Index("enrolment_business_idx", business_id)
@@ -387,7 +387,7 @@ class PendingSurveys(Base):
     email_address = Column(Text, primary_key=True)
     business_id = Column(UUID, primary_key=True)
     survey_id = Column(Text, primary_key=True)
-    time_shared = Column(DateTime, default=datetime.datetime.utcnow)
+    time_shared = Column(DateTime, default=datetime.now(UTC))
     shared_by = Column(UUID)
     batch_no = Column(UUID, default=uuid.uuid4)
     is_transfer = Column(Boolean, default=False)

--- a/ras_party/models/models.py
+++ b/ras_party/models/models.py
@@ -39,7 +39,7 @@ class Business(Base):
     attributes = relationship(
         "BusinessAttributes", backref="business", order_by="desc(BusinessAttributes.created_on)", lazy="joined"
     )
-    created_on = Column(DateTime(timezone=True), default=func.now())
+    created_on = Column(DateTime, default=func.now())
 
     @staticmethod
     def validate(json_packet, schema):
@@ -188,7 +188,7 @@ class BusinessAttributes(Base):
     sample_summary_id = Column(Text)
     collection_exercise = Column(Text)
     attributes = Column(JSONB)
-    created_on = Column(DateTime(timezone=True), default=func.now())
+    created_on = Column(DateTime, default=func.now())
     name = Column(Text)  # New columns placed at end of list in case code uses positional rather than named references
     trading_as = Column(Text)
     Index("attributes_name_idx", name)
@@ -232,9 +232,9 @@ class BusinessRespondent(Base):
     business_id = Column(UUID, ForeignKey("business.party_uuid"), primary_key=True)
     respondent_id = Column(Integer, ForeignKey("respondent.id"), primary_key=True)
     status = Column("status", Enum(BusinessRespondentStatus), default=BusinessRespondentStatus.ACTIVE)
-    effective_from = Column(DateTime(timezone=True), default=func.now())
-    effective_to = Column(DateTime(timezone=True))
-    created_on = Column(DateTime(timezone=True), default=func.now())
+    effective_from = Column(DateTime, default=func.now())
+    effective_to = Column(DateTime)
+    created_on = Column(DateTime, default=func.now())
 
     business = relationship("Business", back_populates="respondents", lazy="joined")
     respondent = relationship("Respondent", back_populates="businesses", lazy="joined")
@@ -257,7 +257,7 @@ class PendingEnrolment(Base):
     business_id = Column(UUID)
     survey_id = Column(UUID)
 
-    created_on = Column(DateTime(timezone=True), default=func.now())
+    created_on = Column(DateTime, default=func.now())
     respondent = relationship("Respondent")
     Index("pending_enrolment_case_idx", case_id)
 
@@ -279,7 +279,7 @@ class Respondent(Base):
     last_name = Column(Text)
     telephone = Column(Text)
     mark_for_deletion = Column(Boolean, default=False)
-    created_on = Column(DateTime(timezone=True), default=func.now())
+    created_on = Column(DateTime, default=func.now())
     password_verification_token = Column(Text)
     password_reset_counter = Column(Integer, default=0)
     pending_enrolment = relationship("PendingEnrolment", back_populates="respondent")
@@ -360,7 +360,7 @@ class Enrolment(Base):
     respondent_id = Column(Integer, primary_key=True)
     survey_id = Column(Text, primary_key=True)
     status = Column("status", Enum(EnrolmentStatus), default=EnrolmentStatus.PENDING)
-    created_on = Column(DateTime(timezone=True), default=func.now())
+    created_on = Column(DateTime, default=func.now())
 
     business_respondent = relationship("BusinessRespondent", back_populates="enrolment", lazy="joined")
     Index("enrolment_business_idx", business_id)
@@ -387,7 +387,7 @@ class PendingSurveys(Base):
     email_address = Column(Text, primary_key=True)
     business_id = Column(UUID, primary_key=True)
     survey_id = Column(Text, primary_key=True)
-    time_shared = Column(DateTime(timezone=True), default=func.now())
+    time_shared = Column(DateTime, default=func.now())
     shared_by = Column(UUID)
     batch_no = Column(UUID, default=uuid.uuid4)
     is_transfer = Column(Boolean, default=False)


### PR DESCRIPTION
# What and why?
Delegates the created_on time retrieval to the built in database method (which saves it in UTC without timezone information - as we have been doing with datetime anyway). This solves the issue we were seeing with using the "new" `datetime.now(UTC)` function replacing the deprecated `datetime.utcnow()` function, which was using the time checked at app startup in the models and not evaluating on each column creation. The instances in the pending survey deletion cron job are evaluated on each request and therefore work as they should.
# How to test?
- deploy to your env
- run the acceptance tests
- check the created on time for the new party 
- create a new account in frontstage
- check the time is not set to almost the same but the correct time the account was created
- share the survey to the other account you have
- check that there is a pending survey share in the `pending_surveys` table
- run `kubectl edit deployments party` and edit the `EMAIL_TOKEN_EXPIRY` to a more reasonable number from 3 days
  - or edit it through the gcloud user interface
- save the changes
- check that after the cron runs the pending survey entry has been deleted from the table
# Jira
[RAS-1378](https://jira.ons.gov.uk/browse/RAS-1378)