### PR TITLE
RAS-1400 Extend party enrolment to include business and survey details

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.13
+version: 2.5.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.13
+appVersion: 2.5.14

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -166,6 +166,12 @@ spec:
             {{- else }}
             value: "http://$(IAC_SERVICE_HOST):$(IAC_SERVICE_PORT)"
             {{- end }}
+          - name: SURVEY_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://survey.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "http://$(SURVEY_SERVICE_HOST):$(SURVEY_SERVICE_PORT)"
+            {{- end }}
           - name: NOTIFY_URL
             {{- if .Values.dns.enabled }}
             value: "http://notify-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}/emails/"

--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ class Config(object):
     COLLECTION_EXERCISE_URL = os.getenv("COLLECTION_EXERCISE_URL")
     FRONTSTAGE_URL = os.getenv("FRONTSTAGE_URL")
     IAC_URL = os.getenv("IAC_URL")
+    SURVEY_URL = os.getenv("SURVEY_URL")
 
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT", "test-project-id")
     PUBSUB_TOPIC = os.getenv("PUBSUB_TOPIC", "ras-rm-notify-test")
@@ -96,6 +97,7 @@ class Config(object):
 class DevelopmentConfig(Config):
     DEBUG = True
     LOGGING_LEVEL = "DEBUG"
+    SURVEY_URL = os.getenv("SURVEY_URL", "http://localhost:8080")
 
 
 class TestingConfig(DevelopmentConfig):

--- a/ras_party/controllers/enrolments_controller.py
+++ b/ras_party/controllers/enrolments_controller.py
@@ -6,10 +6,12 @@ from flask import session
 from sqlalchemy.orm.exc import NoResultFound
 
 from ras_party.controllers.queries import (
+    query_enrolment_by_survey_business_respondent,
     query_respondent_by_party_uuid,
     query_respondent_enrolments,
 )
-from ras_party.models.models import Enrolment
+from ras_party.controllers.survey_controller import get_surveys_details
+from ras_party.models.models import Enrolment, RespondentStatus
 from ras_party.support.session_decorator import with_query_only_db_session
 
 logger = structlog.wrap_logger(logging.getLogger(__name__))
@@ -20,11 +22,50 @@ def respondent_enrolments(
     session: session, party_uuid: UUID, business_id: UUID = None, survey_id: UUID = None, status: int = None
 ) -> list[Enrolment]:
     """
-    returns a list of respondent Enrolments. Business_id, survey_id and status can also be added as conditions
+    returns a list of respondent enrolments with business and survey details
     """
 
     respondent = query_respondent_by_party_uuid(party_uuid, session)
     if not respondent:
         raise NoResultFound
 
-    return query_respondent_enrolments(session, respondent.id, business_id, survey_id, status)
+    enrolments = query_respondent_enrolments(session, respondent.id, business_id, survey_id, status)
+
+    if not enrolments:
+        return []
+
+    surveys_details = get_surveys_details()
+    respondents_enrolled = []
+    for enrolment, business_ref, business_attributes in enrolments:
+        survey_id = enrolment.survey_id
+        respondents_enrolled.append(
+            (
+                {
+                    "enrolment_status": enrolment.status.name,
+                    "business_details": {
+                        "id": enrolment.business_id,
+                        "name": business_attributes["name"],
+                        "trading_as": business_attributes["trading_as"],
+                        "ref": business_ref,
+                    },
+                    "survey_details": {
+                        "id": survey_id,
+                        "long_name": surveys_details.get(survey_id)["long_name"],
+                        "short_name": surveys_details.get(survey_id)["short_name"],
+                        "ref": surveys_details.get(survey_id)["ref"],
+                    },
+                }
+            )
+        )
+    return respondents_enrolled
+
+
+@with_query_only_db_session
+def is_respondent_enrolled(party_uuid: UUID, business_id: UUID, survey_id: UUID, session: session) -> bool:
+    respondent = query_respondent_by_party_uuid(party_uuid, session)
+
+    if respondent and respondent.status == RespondentStatus.ACTIVE:
+        enrolment = query_enrolment_by_survey_business_respondent(respondent.id, business_id, survey_id, session)
+        if enrolment:
+            return True
+    return False

--- a/ras_party/controllers/queries.py
+++ b/ras_party/controllers/queries.py
@@ -660,4 +660,10 @@ def query_respondent_enrolments(
     if status:
         additional_conditions.append(Enrolment.status == status)
 
-    return session.query(Enrolment).filter(and_(Enrolment.respondent_id == respondent_id, *additional_conditions)).all()
+    return (
+        session.query(Enrolment, Business.business_ref, BusinessAttributes.attributes)
+        .join(Business, Business.party_uuid == Enrolment.business_id)
+        .join(BusinessAttributes, BusinessAttributes.business_id == Enrolment.business_id)
+        .filter(and_(Enrolment.respondent_id == respondent_id, *additional_conditions))
+        .all()
+    )

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -13,7 +13,6 @@ from ras_party.controllers.account_controller import (
 )
 from ras_party.controllers.notify_gateway import NotifyGateway
 from ras_party.controllers.queries import (
-    query_enrolment_by_survey_business_respondent,
     query_respondent_by_email,
     query_respondent_by_names_and_emails,
     query_respondent_by_party_uuid,
@@ -26,7 +25,6 @@ from ras_party.models.models import (
     Enrolment,
     PendingEnrolment,
     Respondent,
-    RespondentStatus,
 )
 from ras_party.support.session_decorator import (
     with_db_session,
@@ -251,14 +249,3 @@ def get_respondents_by_survey_and_business_id(survey_id: UUID, business_id: UUID
         )
 
     return respondents_enrolled
-
-
-@with_query_only_db_session
-def is_user_enrolled(party_uuid: UUID, business_id: UUID, survey_id: UUID, session: session) -> bool:
-    respondent = query_respondent_by_party_uuid(party_uuid, session)
-
-    if respondent and respondent.status == RespondentStatus.ACTIVE:
-        enrolment = query_enrolment_by_survey_business_respondent(respondent.id, business_id, survey_id, session)
-        if enrolment:
-            return True
-    return False

--- a/ras_party/controllers/survey_controller.py
+++ b/ras_party/controllers/survey_controller.py
@@ -1,0 +1,31 @@
+import logging
+
+import requests
+import structlog
+from flask import current_app
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+
+from ras_party.exceptions import ServiceUnavailableException
+
+logger = structlog.wrap_logger(logging.getLogger(__name__))
+
+
+def get_surveys_details() -> dict:
+    url = f'{current_app.config["SURVEY_URL"]}/surveys'
+    try:
+        response = requests.get(
+            url, auth=(current_app.config["SECURITY_USER_NAME"], current_app.config["SECURITY_USER_PASSWORD"])
+        )
+        response.raise_for_status()
+    except HTTPError:
+        logger.error("Survey returned a HTTPError")
+        raise
+    except ConnectionError:
+        raise ServiceUnavailableException("Survey service returned a connection error", 503)
+    except Timeout:
+        raise ServiceUnavailableException("Survey service has timed out", 504)
+
+    return {
+        survey["id"]: {"short_name": survey["shortName"], "long_name": survey["longName"], "ref": survey["surveyRef"]}
+        for survey in response.json()
+    }

--- a/ras_party/exceptions.py
+++ b/ras_party/exceptions.py
@@ -4,3 +4,14 @@ class RasNotifyError(Exception):
         self.error = error
         for k, v in kwargs.items():
             self.__dict__[k] = v
+
+
+class ServiceUnavailableException(Exception):
+    status_code = 500
+
+    def __init__(self, errors, status_code=None):
+        self.errors = errors if isinstance(errors, list) else [errors]
+        self.status_code = status_code
+
+    def to_dict(self):
+        return {"errors": self.errors}

--- a/ras_party/views/respondent_view.py
+++ b/ras_party/views/respondent_view.py
@@ -7,6 +7,7 @@ from flask_httpauth import HTTPBasicAuth
 from werkzeug.exceptions import BadRequest
 
 from ras_party.controllers import respondent_controller
+from ras_party.controllers.enrolments_controller import is_respondent_enrolled
 from ras_party.uuid_helper import is_valid_uuid4
 
 logger = structlog.wrap_logger(logging.getLogger(__name__))
@@ -132,7 +133,7 @@ def validate_respondent_claim():
     if not (is_valid_uuid4(party_uuid) and is_valid_uuid4(business_id) and is_valid_uuid4(survey_id)):
         return make_response("Bad request, party_uuid, business or survey id not UUID", 400)
 
-    if respondent_controller.is_user_enrolled(party_uuid, business_id, survey_id):
+    if is_respondent_enrolled(party_uuid, business_id, survey_id):
         return make_response("Valid", 200)
 
     return make_response("Invalid", 200)

--- a/test/party_client.py
+++ b/test/party_client.py
@@ -450,3 +450,12 @@ class PartyTestClient(TestCase):
             f"/party-api/v1/enrolments/respondent/{party_id}", json=payload, headers=self.auth_headers
         )
         return response
+
+    def get_respondent_is_enrolments(self, party_uuid, business_id, survey_id):
+        response = self.client.get(
+            f"/party-api/v1/enrolments/is_respondent_enrolled/{party_uuid}"
+            f"/business_id/{business_id}"
+            f"/survey_id/{survey_id}",
+            headers=self.auth_headers,
+        )
+        return response

--- a/test/test_enrolments_controller.py
+++ b/test/test_enrolments_controller.py
@@ -1,4 +1,6 @@
 from test.party_client import PartyTestClient
+from unittest.mock import patch
+from uuid import UUID
 
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
@@ -6,6 +8,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from ras_party.controllers.enrolments_controller import respondent_enrolments
 from ras_party.models.models import (
     Business,
+    BusinessAttributes,
     BusinessRespondent,
     Enrolment,
     EnrolmentStatus,
@@ -18,12 +21,16 @@ respondents_enrolments = [
         "respondent": "b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85",
         "enrolment_details": [
             {
-                "business": "75d9af56-1225-4d43-b41d-1199f5f89daa",
+                "business_id": "75d9af56-1225-4d43-b41d-1199f5f89daa",
+                "business_ref": "001",
+                "business_attributes": {"name": "Business 1", "trading_as": "1 Business"},
                 "survey_id": "9200d295-9d6e-41fe-b541-747ae67a279f",
                 "status": EnrolmentStatus.ENABLED,
             },
             {
-                "business": "98e2c9dd-a760-47dd-ba18-439fd5fb93a3",
+                "business_id": "98e2c9dd-a760-47dd-ba18-439fd5fb93a3",
+                "business_ref": "002",
+                "business_attributes": {"name": "Business 2", "trading_as": "2 Business"},
                 "survey_id": "c641f6ad-a5eb-4d82-a647-7cd586549bbc",
                 "status": EnrolmentStatus.ENABLED,
             },
@@ -33,12 +40,16 @@ respondents_enrolments = [
         "respondent": "5718649e-30bf-4c25-a2c0-aaa733e54ed6",
         "enrolment_details": [
             {
-                "business": "af25c9d5-6893-4342-9d24-4b88509e965f",
+                "business_id": "af25c9d5-6893-4342-9d24-4b88509e965f",
+                "business_ref": "003",
+                "business_attributes": {"name": "Business 3", "trading_as": "3 Business"},
                 "survey_id": "9200d295-9d6e-41fe-b541-747ae67a279f",
                 "status": EnrolmentStatus.ENABLED,
             },
             {
-                "business": "75d9af56-1225-4d43-b41d-1199f5f89daa",
+                "business_id": "75d9af56-1225-4d43-b41d-1199f5f89daa",
+                "business_ref": "004",
+                "business_attributes": {"name": "Business 4", "trading_as": "4 Business"},
                 "survey_id": "9200d295-9d6e-41fe-b541-747ae67a279f",
                 "status": EnrolmentStatus.DISABLED,
             },
@@ -46,20 +57,62 @@ respondents_enrolments = [
     },
 ]
 
+SURVEYS_DETAILS = {
+    "c641f6ad-a5eb-4d82-a647-7cd586549bbc": {"long_name": "Survey 1", "short_name": "S1", "ref": "S001"},
+    "9200d295-9d6e-41fe-b541-747ae67a279f": {"long_name": "Survey 2", "short_name": "S2", "ref": "S002"},
+}
+
 
 class TestEnrolments(PartyTestClient):
 
     def setUp(self):
         self._add_enrolments()
 
-    def test_get_enrolments_party_id(self):
+    @patch("ras_party.controllers.enrolments_controller.get_surveys_details")
+    def test_get_enrolments_party_id(self, get_surveys_details):
+        get_surveys_details.return_value = SURVEYS_DETAILS
         enrolments = respondent_enrolments(party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
-
+        print(enrolments)
         self.assertEqual(len(enrolments), 2)
-        self.assertEqual(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertEqual(str(enrolments[1].business_id), "98e2c9dd-a760-47dd-ba18-439fd5fb93a3")
+        self.assertEqual(
+            enrolments,
+            [
+                {
+                    "enrolment_status": "ENABLED",
+                    "business_details": {
+                        "id": UUID("75d9af56-1225-4d43-b41d-1199f5f89daa"),
+                        "name": "Business 1",
+                        "trading_as": "1 Business",
+                        "ref": "001",
+                    },
+                    "survey_details": {
+                        "id": "9200d295-9d6e-41fe-b541-747ae67a279f",
+                        "long_name": "Survey 2",
+                        "short_name": "S2",
+                        "ref": "S002",
+                    },
+                },
+                {
+                    "enrolment_status": "ENABLED",
+                    "business_details": {
+                        "id": UUID("98e2c9dd-a760-47dd-ba18-439fd5fb93a3"),
+                        "name": "Business 2",
+                        "trading_as": "2 Business",
+                        "ref": "002",
+                    },
+                    "survey_details": {
+                        "id": "c641f6ad-a5eb-4d82-a647-7cd586549bbc",
+                        "long_name": "Survey 1",
+                        "short_name": "S1",
+                        "ref": "S001",
+                    },
+                },
+            ],
+        )
 
-    def test_get_enrolments_party_id_and_business_id_and_survey_id(self):
+    @patch("ras_party.controllers.enrolments_controller.get_surveys_details")
+    def test_get_enrolments_party_id_and_business_id_and_survey_id(self, get_surveys_details):
+        get_surveys_details.return_value = SURVEYS_DETAILS
         enrolments = respondent_enrolments(
             party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85",
             business_id="75d9af56-1225-4d43-b41d-1199f5f89daa",
@@ -67,27 +120,38 @@ class TestEnrolments(PartyTestClient):
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertEqual(str(enrolments[0].respondent_id), "1")
-        self.assertEqual(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertEqual(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0]["business_details"]["id"]), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertEqual(str(enrolments[0]["survey_details"]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
-    def test_get_enrolments_party_id_enabled(self):
+    @patch("ras_party.controllers.enrolments_controller.get_surveys_details")
+    def test_get_enrolments_party_id_enabled(self, get_surveys_details):
+        get_surveys_details.return_value = SURVEYS_DETAILS
         enrolments = respondent_enrolments(
             party_uuid="5718649e-30bf-4c25-a2c0-aaa733e54ed6", status=EnrolmentStatus.ENABLED
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertEqual(str(enrolments[0].business_id), "af25c9d5-6893-4342-9d24-4b88509e965f")
-        self.assertEqual(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0]["business_details"]["id"]), "af25c9d5-6893-4342-9d24-4b88509e965f")
+        self.assertEqual(str(enrolments[0]["survey_details"]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
-    def test_get_enrolments_party_id_disabled(self):
+    @patch("ras_party.controllers.enrolments_controller.get_surveys_details")
+    def test_get_enrolments_party_id_disabled(self, get_surveys_details):
+        get_surveys_details.return_value = SURVEYS_DETAILS
         enrolments = respondent_enrolments(
             party_uuid="5718649e-30bf-4c25-a2c0-aaa733e54ed6", status=EnrolmentStatus.DISABLED
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertEqual(str(enrolments[0].business_id), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertEqual(str(enrolments[0].survey_id), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0]["business_details"]["id"]), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertEqual(str(enrolments[0]["survey_details"]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
+
+    def test_get_enrolments_no_enrolments(
+        self,
+    ):
+        enrolments = respondent_enrolments(
+            party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85", survey_id="8200d295-9d6e-41fe-b541-747ae67a279f"
+        )
+        self.assertEqual(len(enrolments), 0)
 
     def test_get_enrolments_party_id_not_found_respondent(self):
         with self.assertRaises(NoResultFound):
@@ -106,10 +170,14 @@ class TestEnrolments(PartyTestClient):
             session.add(respondent)
 
             for enrolment in respondent_enrolment["enrolment_details"]:
-                if not (business := businesses.get(enrolment["business"])):
-                    business = Business(party_uuid=enrolment["business"])
+                if not (business := businesses.get(enrolment["business_id"])):
+                    business = Business(party_uuid=enrolment["business_id"], business_ref=enrolment["business_ref"])
+                    business_attributes = BusinessAttributes(
+                        business_id=business.party_uuid, attributes=enrolment["business_attributes"]
+                    )
                     session.add(business)
-                    businesses[enrolment["business"]] = business
+                    session.add(business_attributes)
+                    businesses[enrolment["business_id"]] = business
 
                 business_respondent = BusinessRespondent(business=business, respondent=respondent)
                 session.add(business_respondent)

--- a/test/test_enrolments_controller.py
+++ b/test/test_enrolments_controller.py
@@ -72,7 +72,6 @@ class TestEnrolments(PartyTestClient):
     def test_get_enrolments_party_id(self, get_surveys_details):
         get_surveys_details.return_value = SURVEYS_DETAILS
         enrolments = respondent_enrolments(party_uuid="b6f9d6e8-b840-4c95-a6ce-9ef145dd1f85")
-        print(enrolments)
         self.assertEqual(len(enrolments), 2)
         self.assertEqual(
             enrolments,

--- a/test/test_enrolments_view.py
+++ b/test/test_enrolments_view.py
@@ -5,32 +5,34 @@ from unittest.mock import patch
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
-from ras_party.models.models import Enrolment, EnrolmentStatus
+PARTY_UUID = "19eec8b9-0319-42db-ba61-6afa2cf77a26"
+BUSINESS_ID = "4844b9ab-68b5-4f60-932b-b3da8df3d480"
+SURVEY_ID = "17b4c9b3-58c2-4a53-991f-00541415b8c3"
 
 
 class TestEnrolmentsView(PartyTestClient):
 
     @patch("ras_party.views.enrolments_view.respondent_enrolments")
     def test_get_enrolments(self, respondent_enrolments):
-        respondent_enrolments.return_value = [
-            Enrolment(
-                business_id="79af714a-ee1d-446c-9f39-763296ec1f05",
-                survey_id="38553552-7d08-42e4-b86b-06f158c4b95e",
-                respondent_id=1,
-                status=EnrolmentStatus.ENABLED,
-            )
-        ]
+        enrolment_details = {
+            "enrolment_status": "ENABLED",
+            "business_details": {
+                "id": "ee1e8401-b5c5-42a3-baf9-02490ce551b1",
+                "name": "business 1",
+                "trading_as": "1 business",
+                "ref": "4900000000",
+            },
+            "survey_details": {
+                "id": "4fae28f9-b4d2-4ca1-9aff-08f5ff3bda3b",
+                "long_name": "Survey 1",
+                "short_name": "S1",
+                "ref": "139",
+            },
+        }
+        respondent_enrolments.return_value = enrolment_details
         response = self.get_respondent_enrolments("b146f595-62a0-4d6d-ba88-ef40cffdf8a7")
 
-        expected_response = [
-            {
-                "business_id": "79af714a-ee1d-446c-9f39-763296ec1f05",
-                "survey_id": "38553552-7d08-42e4-b86b-06f158c4b95e",
-                "status": "ENABLED",
-            }
-        ]
-
-        self.assertEqual(expected_response, json.loads(response.data))
+        self.assertEqual(enrolment_details, json.loads(response.data))
 
     @patch("ras_party.views.enrolments_view.respondent_enrolments")
     def test_get_enrolments_not_found_respondent(self, respondent_enrolments):
@@ -48,5 +50,26 @@ class TestEnrolmentsView(PartyTestClient):
 
     def test_get_enrolments_no_params(self):
         response = self.get_respondent_enrolments({})
+
+        self.assertEqual(400, response.status_code)
+
+    @patch("ras_party.views.enrolments_view.is_respondent_enrolled")
+    def test_get_respondent_is_enrolments(self, is_respondent_enrolled):
+        is_respondent_enrolled.return_value = True
+        response = self.get_respondent_is_enrolments(PARTY_UUID, BUSINESS_ID, SURVEY_ID)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"enrolled": True}, json.loads(response.data))
+
+    @patch("ras_party.views.enrolments_view.is_respondent_enrolled")
+    def test_get_respondent_is_enrolments_false(self, is_respondent_enrolled):
+        is_respondent_enrolled.return_value = False
+        response = self.get_respondent_is_enrolments(PARTY_UUID, BUSINESS_ID, SURVEY_ID)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"enrolled": False}, json.loads(response.data))
+
+    def test_get_respondent_is_enrolments_malformed(self):
+        response = self.get_respondent_is_enrolments("malformed_id", BUSINESS_ID, SURVEY_ID)
 
         self.assertEqual(400, response.status_code)

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -1166,6 +1166,7 @@ class TestRespondents(PartyTestClient):
                 personalisation=personalisation_old,
             ),
         ]
+
         self.assertEqual(call_args_list, self.mock_notify.request_to_notify.call_args_list)
 
     def test_email_verification_activates_a_respondent(self):

--- a/test/test_survey_controller.py
+++ b/test/test_survey_controller.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch
+
+from requests import ConnectionError, HTTPError, Timeout
+from requests.models import Response
+
+from ras_party.controllers.survey_controller import get_surveys_details
+from ras_party.exceptions import ServiceUnavailableException
+from run import create_app
+
+
+class TestConversationController(unittest.TestCase):
+
+    def setUp(self):
+        self.app = create_app("TestingConfig")
+
+    def test_get_surveys_details(self):
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response._content = (
+            b'[{"id": "41320b22-b425-4fba-a90e-718898f718ce", "shortName": "AIFDI", "longName": '
+            b'"Annual Inward Foreign Direct Investment Survey", "surveyRef": "062"}]'
+        )
+
+        with patch("requests.get", return_value=mock_response):
+            with self.app.app_context():
+                surveys_details = get_surveys_details()
+
+        self.assertEqual(
+            surveys_details,
+            {
+                "41320b22-b425-4fba-a90e-718898f718ce": {
+                    "short_name": "AIFDI",
+                    "long_name": "Annual Inward Foreign Direct Investment Survey",
+                    "ref": "062",
+                }
+            },
+        )
+
+    def test_get_surveys_details_connection_error(self):
+        with patch("requests.get", side_effect=ConnectionError):
+            with self.app.app_context():
+                with self.assertRaises(ServiceUnavailableException):
+                    get_surveys_details()
+
+    def test_get_surveys_details_timeout(self):
+        with patch("requests.get", side_effect=Timeout):
+            with self.app.app_context():
+                with self.assertRaises(ServiceUnavailableException):
+                    get_surveys_details()
+
+    def test_get_surveys_details_http_error(self):
+        with patch("requests.get", side_effect=HTTPError):
+            with self.app.app_context():
+                with self.assertRaises(HTTPError):
+                    get_surveys_details()


### PR DESCRIPTION
# What and why?
This PR updates the enrolment information endpoint, instead of just posting busines_ids and survey_ids it provides all the bits that are needed. It also adds a new endpoint just to checkout enrolment
# How to test?
Deploy this card as well https://github.com/ONSdigital/ras-frontstage/pull/1016. Add some enrolment data to your account, acceptance tests could be used, but you might want to add another IAC as well. If it logs in you are good. Also check you can access a eq, download and upload a seft. Equally you can just call the endpoints on this service


N.B there is a chart addition so you will need to deploy this via helm or provide the survey_url env. (i.e helm install party ./_infra/helm/party) don't forget if you already have a party service deployed via spinnaker you will need to kill the current deployments, service etc

```kubectl delete deployment party --namespace <your namespace>
kubectl delete service party --namespace <your namespace>
kubectl delete cronjob party-scheduler-delete-respondents --namespace <your namespace>
kubectl delete cronjob party-scheduler-remove-expired-pending-surveys --namespace <your namespace>
kubectl delete externalsecret party --namespace <your namespace>
