### PR TITLE
RAS-1467 Change return format for enrolments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,18 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731
+	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 74735
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8 --exclude=./scripts
 
 lint-check:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731
+	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 74735
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8 --exclude=./scripts
 
-test: lint-check
+test:
 	APP_SETTINGS=TestingConfig pipenv run pytest test --cov ras_party --cov-report term-missing
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,18 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 74735
+	pipenv check -i 42194
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8 --exclude=./scripts
 
 lint-check:
-	pipenv check -i 42194 -i 70612 -i 70624 -i 72731 -i 74735
+	pipenv check -i 42194
 	pipenv run isort . --check-only
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8 --exclude=./scripts
 
-test:
+test: lint-check
 	APP_SETTINGS=TestingConfig pipenv run pytest test --cov ras_party --cov-report term-missing
 
 start:

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.16
+version: 2.5.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.16
+appVersion: 2.5.17

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.15
+version: 2.5.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.15
+appVersion: 2.5.16

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1718,28 +1718,27 @@ components:
     RespondentEnrolments:
       type: object
       properties:
-        enrolment_status:
+        business_id:
+          format: uuid
+        business_name:
           type: string
-          enum: [PENDING, ENABLED, DISABLED, SUSPENDED]
-        business_details:
-          type: object
-          properties:
-            id:
-              format: uuid
-            name:
-              type: string
-            trading_as:
-              type: string
-            ref:
-              type: string
+        trading_as:
+          type: string
+        ru_ref:
+          type: string
         survey_details:
-          type: object
-          properties:
-            id:
-              format: uuid
-            long_name:
-              type: string
-            short_name:
-              type: string
-            ref:
-              type: string
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                format: uuid
+              long_name:
+                type: string
+              short_name:
+                type: string
+              ref:
+                type: string
+              enrolment_status:
+                type: string
+                enum: [ PENDING, ENABLED, DISABLED, SUSPENDED ]

--- a/ras_party/controllers/enrolments_controller.py
+++ b/ras_party/controllers/enrolments_controller.py
@@ -39,7 +39,6 @@ def respondent_enrolments(
     enrolments_map = defaultdict(_business_survey_details)
 
     for enrolment in enrolments:
-        print(enrolment)
         business_ref = enrolment.business_ref
         survey_id = enrolment.survey_id
 

--- a/test/test_enrolments_controller.py
+++ b/test/test_enrolments_controller.py
@@ -95,34 +95,34 @@ class TestEnrolments(PartyTestClient):
             enrolments,
             [
                 {
-                    "enrolment_status": "ENABLED",
-                    "business_details": {
-                        "id": UUID("75d9af56-1225-4d43-b41d-1199f5f89daa"),
-                        "name": "Business 4",  # Business 4 is the latest business_attributes for 75d9af56
-                        "trading_as": "4 Business",
-                        "ref": "001",
-                    },
-                    "survey_details": {
-                        "id": "9200d295-9d6e-41fe-b541-747ae67a279f",
-                        "long_name": "Survey 2",
-                        "short_name": "S2",
-                        "ref": "S002",
-                    },
+                    "business_name": "Business 4",
+                    "business_id": UUID("75d9af56-1225-4d43-b41d-1199f5f89daa"),
+                    "ru_ref": "001",
+                    "trading_as": "4 Business",
+                    "survey_details": [
+                        {
+                            "id": "9200d295-9d6e-41fe-b541-747ae67a279f",
+                            "long_name": "Survey 2",
+                            "short_name": "S2",
+                            "ref": "S002",
+                            "enrolment_status": "ENABLED",
+                        }
+                    ],
                 },
                 {
-                    "enrolment_status": "ENABLED",
-                    "business_details": {
-                        "id": UUID("98e2c9dd-a760-47dd-ba18-439fd5fb93a3"),
-                        "name": "Business 2",
-                        "trading_as": "2 Business",
-                        "ref": "002",
-                    },
-                    "survey_details": {
-                        "id": "c641f6ad-a5eb-4d82-a647-7cd586549bbc",
-                        "long_name": "Survey 1",
-                        "short_name": "S1",
-                        "ref": "S001",
-                    },
+                    "business_name": "Business 2",
+                    "business_id": UUID("98e2c9dd-a760-47dd-ba18-439fd5fb93a3"),
+                    "ru_ref": "002",
+                    "trading_as": "2 Business",
+                    "survey_details": [
+                        {
+                            "id": "c641f6ad-a5eb-4d82-a647-7cd586549bbc",
+                            "long_name": "Survey 1",
+                            "short_name": "S1",
+                            "ref": "S001",
+                            "enrolment_status": "ENABLED",
+                        }
+                    ],
                 },
             ],
         )
@@ -137,8 +137,8 @@ class TestEnrolments(PartyTestClient):
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertEqual(str(enrolments[0]["business_details"]["id"]), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertEqual(str(enrolments[0]["survey_details"]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0]["business_id"]), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertEqual(str(enrolments[0]["survey_details"][0]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     @patch("ras_party.controllers.enrolments_controller.get_surveys_details")
     def test_get_enrolments_party_id_enabled(self, get_surveys_details):
@@ -148,8 +148,8 @@ class TestEnrolments(PartyTestClient):
         )
 
         self.assertEqual(len(enrolments), 1)
-        self.assertEqual(str(enrolments[0]["business_details"]["id"]), "af25c9d5-6893-4342-9d24-4b88509e965f")
-        self.assertEqual(str(enrolments[0]["survey_details"]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0]["business_id"]), "af25c9d5-6893-4342-9d24-4b88509e965f")
+        self.assertEqual(str(enrolments[0]["survey_details"][0]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     @patch("ras_party.controllers.enrolments_controller.get_surveys_details")
     def test_get_enrolments_party_id_disabled(self, get_surveys_details):
@@ -157,10 +157,9 @@ class TestEnrolments(PartyTestClient):
         enrolments = respondent_enrolments(
             party_uuid="5718649e-30bf-4c25-a2c0-aaa733e54ed6", status=EnrolmentStatus.DISABLED.name
         )
-
         self.assertEqual(len(enrolments), 1)
-        self.assertEqual(str(enrolments[0]["business_details"]["id"]), "75d9af56-1225-4d43-b41d-1199f5f89daa")
-        self.assertEqual(str(enrolments[0]["survey_details"]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
+        self.assertEqual(str(enrolments[0]["business_id"]), "75d9af56-1225-4d43-b41d-1199f5f89daa")
+        self.assertEqual(str(enrolments[0]["survey_details"][0]["id"]), "9200d295-9d6e-41fe-b541-747ae67a279f")
 
     def test_get_enrolments_no_enrolments(
         self,
@@ -195,6 +194,8 @@ class TestEnrolments(PartyTestClient):
                     business_id=business.party_uuid,
                     attributes=enrolment["business_attributes"],
                     created_on=enrolment["business_attributes"]["created_on"],
+                    name=enrolment["business_attributes"]["name"],
+                    trading_as=enrolment["business_attributes"]["trading_as"],
                 )
                 session.add(business_attributes)
                 business_respondent = BusinessRespondent(business=business, respondent=respondent)

--- a/test/test_enrolments_view.py
+++ b/test/test_enrolments_view.py
@@ -14,21 +14,23 @@ class TestEnrolmentsView(PartyTestClient):
 
     @patch("ras_party.views.enrolments_view.respondent_enrolments")
     def test_get_enrolments(self, respondent_enrolments):
-        enrolment_details = {
-            "enrolment_status": "ENABLED",
-            "business_details": {
-                "id": "ee1e8401-b5c5-42a3-baf9-02490ce551b1",
-                "name": "business 1",
-                "trading_as": "1 business",
-                "ref": "4900000000",
-            },
-            "survey_details": {
-                "id": "4fae28f9-b4d2-4ca1-9aff-08f5ff3bda3b",
-                "long_name": "Survey 1",
-                "short_name": "S1",
-                "ref": "139",
-            },
-        }
+        enrolment_details = [
+            {
+                "business_name": "Business 1",
+                "business_id": "75d9af56-1225-4d43-b41d-1199f5f89daa",
+                "ru_ref": "001",
+                "trading_as": "1 Business",
+                "survey_details": [
+                    {
+                        "id": "9200d295-9d6e-41fe-b541-747ae67a279f",
+                        "long_name": "Survey 1",
+                        "short_name": "S1",
+                        "ref": "S001",
+                        "enrolment_status": "ENABLED",
+                    }
+                ],
+            }
+        ]
         respondent_enrolments.return_value = enrolment_details
         response = self.get_respondent_enrolments("b146f595-62a0-4d6d-ba88-ef40cffdf8a7")
 


### PR DESCRIPTION
# What and why?
This PR changes the format of enrolments endpoint to 

```
            [{
                "business_id": "bebee450-46da-4f8b-a7a6-d4632087f2a3",
                "business_name": "Test Business 1",
                "ru_ref": "49910000014",
                "trading_as": "Trading as Test Business 1",
                "survey_details": [
                    {
                        "id": "41320b22-b425-4fba-a90e-718898f718ce",
                        "short_name": "AIFDI",
                        "long_name": "Annual Inward Foreign Direct Investment Survey",
                        "ref": "062",
                        "enrolment_status": "ENABLED",
                    }
                ],
            }, ...
]
```
# How to test?
Make sure that the format has been changed and tests reflect the change
# Jira
