### PR TITLE
Add logging and exception handling to delete respondents

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -170,11 +170,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
+            "version": "==8.1.8"
         },
         "deprecated": {
             "hashes": [
@@ -485,11 +485,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
-                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+                "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb",
+                "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.4"
+            "version": "==3.1.5"
         },
         "jsonschema": {
             "hashes": [

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.15
+version: 2.5.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.15
+appVersion: 2.5.16

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -131,7 +131,7 @@ def delete_respondents_marked_for_deletion(session):
     """
     respondents = session.query(Respondent).filter(Respondent.mark_for_deletion == True)  # noqa
     for respondent in respondents:
-        bound_logger = logger.bind(email=obfuscate_email(respondent.email_address, respondent_id=respondent.id))
+        bound_logger = logger.bind(email=obfuscate_email(respondent.email_address), respondent_id=respondent.id)
         bound_logger.info("Attempting to delete respondent records")
         try:
             session.query(Enrolment).filter(Enrolment.respondent_id == respondent.id).delete()

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -148,7 +148,7 @@ def delete_respondents_marked_for_deletion(session):
             send_account_deletion_confirmation_email(respondent.email_address, respondent.first_name)
             bound_logger.info("Respondent records deleted successfully")
         except IntegrityError as e:
-            logger.error(
+            bound_logger.error(
                 "A data constraint violation occurred trying to delete the respondent records",
                 respondent_id=respondent.id,
                 party_uuid=respondent.party_uuid,
@@ -157,7 +157,7 @@ def delete_respondents_marked_for_deletion(session):
             session.rollback()
             failed_deletion_count += 1
         except SQLAlchemyError as e:
-            logger.error(
+            bound_logger.error(
                 "An error occurred trying to delete the respondent records",
                 respondent_id=respondent.id,
                 party_uuid=respondent.party_uuid,

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -131,7 +131,9 @@ def delete_respondents_marked_for_deletion(session):
     """
     respondents = session.query(Respondent).filter(Respondent.mark_for_deletion == True)  # noqa
     for respondent in respondents:
-        bound_logger = logger.bind(email=obfuscate_email(respondent.email_address), respondent_id=respondent.id)
+        bound_logger = logger.bind(email=obfuscate_email(respondent.email_address),
+                                   respondent_id=respondent.id,
+                                   party_uuid=respondent.party_uuid)
         bound_logger.info("Attempting to delete respondent records")
         try:
             session.query(Enrolment).filter(Enrolment.respondent_id == respondent.id).delete()

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -146,13 +146,17 @@ def delete_respondents_marked_for_deletion(session):
             bound_logger.info("Respondent records deleted successfully")
         except IntegrityError as e:
             logger.error(
-                "An data constraint violation occurred trying to delete the respondent records",
-                respondent_id=Respondent.id,
+                "A data constraint violation occurred trying to delete the respondent records",
+                respondent_id=respondent.id,
+                party_uuid=respondent.party_uuid,
                 error=str(e),
             )
         except SQLAlchemyError as e:
             logger.error(
-                "An error occurred trying to delete the respondent records", respondent_id=Respondent.id, error=str(e)
+                "An error occurred trying to delete the respondent records",
+                respondent_id=respondent.id,
+                party_uuid=respondent.party_uuid,
+                error=str(e)
             )
 
 

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -144,7 +144,10 @@ def delete_respondents_marked_for_deletion(session):
         )
         bound_logger.info("Attempting to delete respondent records")
         try:
-            delete_respondent_records(session, respondent)
+            session.query(Enrolment).filter(Enrolment.respondent_id == respondent.id).delete()
+            session.query(BusinessRespondent).filter(BusinessRespondent.respondent_id == respondent.id).delete()
+            session.query(PendingEnrolment).filter(PendingEnrolment.respondent_id == respondent.id).delete()
+            session.query(Respondent).filter(Respondent.id == respondent.id).delete()
             session.commit()
             send_account_deletion_confirmation_email(respondent.email_address, respondent.first_name)
             bound_logger.info("Respondent records deleted successfully")
@@ -167,22 +170,6 @@ def delete_respondents_marked_for_deletion(session):
             session.rollback()
             failed_deletion_count += 1
     logger.info("Respondent record deletions complete", failed_deletion_count=failed_deletion_count)
-
-
-def delete_respondent_records(session, respondent):
-    """
-    Deletes all records associated with a respondent.
-
-    :param session: The transactional db session that can be rolled back
-    :param respondent: The respondent whose records are to be deleted
-    :type respondent: Respondent
-    :raises IntegrityError: If there is a data constraint violation
-    :raises SQLAlchemyError: If there is a general SQLAlchemy error
-    """
-    session.query(Enrolment).filter(Enrolment.respondent_id == respondent.id).delete()
-    session.query(BusinessRespondent).filter(BusinessRespondent.respondent_id == respondent.id).delete()
-    session.query(PendingEnrolment).filter(PendingEnrolment.respondent_id == respondent.id).delete()
-    session.query(Respondent).filter(Respondent.id == respondent.id).delete()
 
 
 def send_account_deletion_confirmation_email(email_address: str, name: str):

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -127,6 +127,10 @@ def delete_respondents_marked_for_deletion(session):
     """
     Deletes all the existing respondents and there associated data which are marked for deletion
 
+    NOTE: We don't delete pending_surveys records as these are subject to their own scheduled deletion
+    An IntegrityError exception will be logged if the respondent record cannot be deleted due
+    to existing pending_surveys records.
+
     :param session A db session
     """
     respondents = session.query(Respondent).filter(Respondent.mark_for_deletion == True)  # noqa

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -145,6 +145,7 @@ def delete_respondents_marked_for_deletion(session):
         bound_logger.info("Attempting to delete respondent records")
         try:
             delete_respondent_records(session, respondent)
+            session.commit()
             send_account_deletion_confirmation_email(respondent.email_address, respondent.first_name)
             bound_logger.info("Respondent records deleted successfully")
         except IntegrityError as e:
@@ -182,7 +183,6 @@ def delete_respondent_records(session, respondent):
     session.query(BusinessRespondent).filter(BusinessRespondent.respondent_id == respondent.id).delete()
     session.query(PendingEnrolment).filter(PendingEnrolment.respondent_id == respondent.id).delete()
     session.query(Respondent).filter(Respondent.id == respondent.id).delete()
-    session.commit()
 
 
 def send_account_deletion_confirmation_email(email_address: str, name: str):

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -167,6 +167,7 @@ def delete_respondents_marked_for_deletion(session):
             failed_deletion_count += 1
     logger.info("Respondent record deletions complete", failed_deletion_count=failed_deletion_count)
 
+
 def delete_respondent_records(session, respondent):
     """
     Deletes all records associated with a respondent.

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -122,6 +122,7 @@ def update_respondent_mark_for_deletion(email: str, session):
         return "respondent does not exist", 404
 
 
+@with_db_session
 def delete_respondents_marked_for_deletion(session):
     """
     Deletes all the existing respondents and there associated data which are marked for deletion
@@ -160,12 +161,11 @@ def delete_respondents_marked_for_deletion(session):
             )
 
 
-@with_db_session
 def delete_respondent_records(session, respondent):
     """
     Deletes all records associated with a respondent.
 
-    :param session: The db session
+    :param session: The transactional db session that can be rolled back
     :param respondent: The respondent whose records are to be deleted
     :type respondent: Respondent
     :raises IntegrityError: If there is a data constraint violation
@@ -175,6 +175,7 @@ def delete_respondent_records(session, respondent):
     session.query(BusinessRespondent).filter(BusinessRespondent.respondent_id == respondent.id).delete()
     session.query(PendingEnrolment).filter(PendingEnrolment.respondent_id == respondent.id).delete()
     session.query(Respondent).filter(Respondent.id == respondent.id).delete()
+    session.commit()
 
 
 def send_account_deletion_confirmation_email(email_address: str, name: str):

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -152,6 +152,7 @@ def delete_respondents_marked_for_deletion(session):
                 party_uuid=respondent.party_uuid,
                 error=str(e),
             )
+            session.rollback()
         except SQLAlchemyError as e:
             logger.error(
                 "An error occurred trying to delete the respondent records",
@@ -159,6 +160,7 @@ def delete_respondents_marked_for_deletion(session):
                 party_uuid=respondent.party_uuid,
                 error=str(e),
             )
+            session.rollback()
 
 
 def delete_respondent_records(session, respondent):

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -144,11 +144,7 @@ def delete_respondents_marked_for_deletion(session):
         )
         bound_logger.info("Attempting to delete respondent records")
         try:
-            session.query(Enrolment).filter(Enrolment.respondent_id == respondent.id).delete()
-            session.query(BusinessRespondent).filter(BusinessRespondent.respondent_id == respondent.id).delete()
-            session.query(PendingEnrolment).filter(PendingEnrolment.respondent_id == respondent.id).delete()
-            session.query(Respondent).filter(Respondent.id == respondent.id).delete()
-            session.commit()
+            _delete_respondent_records(respondent, session)
             send_account_deletion_confirmation_email(respondent.email_address, respondent.first_name)
             bound_logger.info("Respondent records deleted successfully")
         except IntegrityError as e:
@@ -170,6 +166,14 @@ def delete_respondents_marked_for_deletion(session):
             session.rollback()
             failed_deletion_count += 1
     logger.info("Respondent record deletions complete", failed_deletion_count=failed_deletion_count)
+
+
+def _delete_respondent_records(respondent, session):
+    session.query(Enrolment).filter(Enrolment.respondent_id == respondent.id).delete()
+    session.query(BusinessRespondent).filter(BusinessRespondent.respondent_id == respondent.id).delete()
+    session.query(PendingEnrolment).filter(PendingEnrolment.respondent_id == respondent.id).delete()
+    session.query(Respondent).filter(Respondent.id == respondent.id).delete()
+    session.commit()
 
 
 def send_account_deletion_confirmation_email(email_address: str, name: str):

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -160,7 +160,7 @@ def delete_respondents_marked_for_deletion(session):
                 "An error occurred trying to delete the respondent records",
                 respondent_id=respondent.id,
                 party_uuid=respondent.party_uuid,
-                error=str(e)
+                error=str(e),
             )
 
 

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -131,9 +131,11 @@ def delete_respondents_marked_for_deletion(session):
     """
     respondents = session.query(Respondent).filter(Respondent.mark_for_deletion == True)  # noqa
     for respondent in respondents:
-        bound_logger = logger.bind(email=obfuscate_email(respondent.email_address),
-                                   respondent_id=respondent.id,
-                                   party_uuid=respondent.party_uuid)
+        bound_logger = logger.bind(
+            email=obfuscate_email(respondent.email_address),
+            respondent_id=respondent.id,
+            party_uuid=respondent.party_uuid,
+        )
         bound_logger.info("Attempting to delete respondent records")
         try:
             session.query(Enrolment).filter(Enrolment.respondent_id == respondent.id).delete()

--- a/test/test_respondent_controller.py
+++ b/test/test_respondent_controller.py
@@ -2071,9 +2071,9 @@ class TestRespondents(PartyTestClient):
 
         # Verify
         expected_confirmation_email_calls = [
-            call(respondent_1.email_address, respondent_1.first_name),
-            call(respondent_2.email_address, respondent_2.first_name),
-            call(respondent_3.email_address, respondent_3.first_name),
+            call("test1@example.com", "One"),
+            call("test2@example.com", "Two"),
+            call("test3@example.com", "Three"),
         ]
         mock_send_account_deletion_confirmation_email.assert_has_calls(expected_confirmation_email_calls)
         self.assertEqual(mock_session.commit.call_count, 3)


### PR DESCRIPTION
# What and why?

Introduces exception handling, db commits, db rollbacks, logging and unit tests for handling batch respondent deletions.

The current implementation terminates mid process if a _single_ DB error is encountered when deleting records. This indiscriminately rolls back previous unrelated respondent record deletions.

As each respondent is unrelated there is no need to stop the process, only to roll back the failing respondent transaction and move onto the next respondent being deleted. We should commit successful deletion transactions before moving onto the next respondent being deleted.

# How to test?

This can be complicated to test due to the permutations of data required, and the potential exceptions that can be thrown. However, an approach is detailed below;

- create four separate accounts
- transfer a survey for account numbers 1 and 3 (i.e create `pending_surveys` for them)
- edit the `auth.user.last_login_date` year of all four respondents from `2025` to `2021` to make them subject to deletion
- run the following CURL commands to action the deletions
```
curl -u admin:secret -X DELETE http://localhost:8041/api/batch/account/users/mark-for-deletion
curl -u admin:secret -X DELETE http://localhost:8041/api/batch/account/users
curl -u admin:secret -X DELETE http://localhost:8081/party-api/v1/batch/respondents
```
- test the behaviour of the current implementation to replicate the bug whereby processing terminates at the first db error (also note the rollback of previously successfully processed deletions)
- test the behaviour of this PR fix 
- check the data to ensure `partysvc.respondents` 2 and 4 are deleted, and also their referenced child records
- check the data to ensure records for respondents 1 and 3 are NOT deleted, nor are their referenced child records
- check the party application logs to ensure all deletions, failed deletions, and counts are accurately logged

# Jira

https://jira.ons.gov.uk/browse/RAS-1460