### PR TITLE
Remove business details for email end point

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.17
+version: 2.5.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.17
+appVersion: 2.5.18

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -70,7 +70,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RespondentWithAssociations'
+                $ref: '#/components/schemas/Respondent'
         404:
           description: The respondent does not exist
   /respondents/{email}:

--- a/ras_party/controllers/respondent_controller.py
+++ b/ras_party/controllers/respondent_controller.py
@@ -237,7 +237,7 @@ def get_respondent_by_email(email: str, session):
         logger.info("Respondent does not exist")
         raise NotFound("Respondent does not exist")
 
-    return respondent.to_respondent_with_associations_dict()
+    return respondent.to_respondent_dict()
 
 
 @with_db_session


### PR DESCRIPTION
# What and why?
The email endpoint does not need to return information regarding the businesses it is associated with. The businesses association code is currently very inefficient and causes issues with performance, we need to remove it where we can

# How to test?
Check the code, ironically all the tests in frontstage and party don't include the association key in it's values, so this corrects them without doing anything. Check repos and the code to make sure that there is no use of the email endpoint business association, then run acceptance tests. I also ran all cron jobs and created my own CE and enrolled on it
# Jira
