### PR TITLE
Allow livenessProbe configuration

### DIFF
--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.35
+version: 2.5.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.35
+appVersion: 2.5.36

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.36
+version: 2.5.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.36
+appVersion: 2.5.37

--- a/_infra/helm/party/templates/deployment.yaml
+++ b/_infra/helm/party/templates/deployment.yaml
@@ -89,13 +89,13 @@ spec:
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /info
+              path: {{ .Values.livenessProbe.httpGet.path }}
               port:  {{ .Values.container.port }}
-            initialDelaySeconds: 1
-            periodSeconds: 20
-            failureThreshold: 5
-            successThreshold: 1
-            timeoutSeconds: 5
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           env:
           - name: AUTH_URL
             {{- if .Values.dns.enabled }}

--- a/_infra/helm/party/values.yaml
+++ b/_infra/helm/party/values.yaml
@@ -54,7 +54,6 @@ rollingUpdate:
 livenessProbe:
   httpGet:
     path: /info
-    port:  {{ .Values.container.port }}
   initialDelaySeconds: 1
   periodSeconds: 20
   failureThreshold: 5

--- a/_infra/helm/party/values.yaml
+++ b/_infra/helm/party/values.yaml
@@ -51,6 +51,16 @@ rollingUpdate:
   maxSurge: 1
   maxUnavailable: 1
 
+livenessProbe:
+  httpGet:
+    path: /info
+    port:  {{ .Values.container.port }}
+  initialDelaySeconds: 1
+  periodSeconds: 20
+  failureThreshold: 5
+  successThreshold: 1
+  timeoutSeconds: 5
+
 email:
   enabled: true
   tokenExpiry: 259200


### PR DESCRIPTION
# What and why?

An initial attempt to stop party receiving a sigterm during highly intensive periods, and understand the errors in party service and csv-worker.

- csv-worker is spamming party with POST `/party`
- this is intended to create the `business` and `business_attributes` records for the sampled unit
- csv-worker doesn't receive a timely response from party, resulting in message being `nacked`
```
Post "http://party.performance.svc.cluster.local:8080/party-api/v1/parties": read tcp 172.20.34.97:48406->172.20.53.42:8080: read: connection reset by peer
error sending HTTP request
error processing party - nacking message
```
- csv-worker receives redelivered message due to previous `nacked` message, and resends request to party exacerbating the problem
- for many sampled units, the `business` and `business_attributes` have already been created and `raise Conflict("party already exists for sample")`
-  this appears to result in a rollback of the transaction, but this might not be necessary as there is no persistence transaction in progress at this point. We might be able to simply log the conflict as info.
```
Rolling back database session due to uncaught exception
party already exists for sample
```
- due to the increasingly slow HTTP responses from the party service, party service fails the `livenessProbe ` and receives a `sigterm` and restarts container exacerbating the problem
- party service DB exception results in transaction rollback 
https://github.com/ONSdigital/ras-party/blob/main/ras_party/controllers/party_controller.py#L23-L45
- attempting to avoid sigterm, despite poor party performance when being spammed by csv-worker https://github.com/ONSdigital/ras-rm-config/blob/increase-memory-for-120k-sample-in-performance/performance/scaled-out/party/values.yaml#L36-L39
