### PR TITLE
Share postgres image version between local dev and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,7 @@ jobs:
           python-version: '3.12'
       - name: Get Dependencies
         run: |
-          docker compose --verbose build
-          docker compose up -d
+          make start-db
           pip install pipenv
           pipenv install --dev
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: build test start
+.PHONY: build test start start-db
 
 build:
 	pipenv install --dev
+
+# The postgres image version is read from _infra/postgres-image, which CI uses too.
+start-db:
+	docker compose --env-file _infra/postgres-image up -d
 
 lint:
 	pipenv run isort .

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ make install
 [Install Docker](https://docs.docker.com/engine/installation/)
 
 ```bash
-docker compose up
+make start-db
 ```
 
 or use the makefile to run

--- a/_infra/helm/party/Chart.yaml
+++ b/_infra/helm/party/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.44
+version: 2.5.45
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.44
+appVersion: 2.5.45

--- a/_infra/postgres-image
+++ b/_infra/postgres-image
@@ -1,0 +1,2 @@
+POSTGRES_IMAGE=postgres:14
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   db:
     container_name: postgres
@@ -7,7 +5,9 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
       POSTGRES_DB: partysvc
-    image: postgres:9.6
+    # Single source of truth, shared with CI. Requires --env-file _infra/postgres-image,
+    # so start this with `make start-db` rather than a bare `docker compose up`.
+    image: ${POSTGRES_IMAGE}
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
# What and why?
Cloud Build starts a postgres container for the test suite, and needs to know which version. Rather than pinning it in two places, the version lives in _infra/postgres-image and is fed to docker-compose via --env-file, so local dev and CI stay in step. Bumps `postgres` from the EOL 9.6 to 14, matching `ras-rm-docker` and the prod.

Compose now requires that flag, so use `make start-db` rather than a bare `docker compose up`.

If you would rather take a different approach, let me know.

# How to test?
Run `make start-db` and see the version started in `docker-compose logs`.

# Jira
* https://officefornationalstatistics.atlassian.net/browse/RAS-1930
* https://officefornationalstatistics.atlassian.net/wiki/spaces/SDC/pages/303956413/Spinnaker+Removal